### PR TITLE
fix(token): use invalid_grant for invalid refresh tokens

### DIFF
--- a/internal/token/api.go
+++ b/internal/token/api.go
@@ -24,7 +24,7 @@ func RegisterHandlers(router *http.ServeMux, config *oidc.Configuration, middlew
 
 func handleCreate(ctx oidc.Context) {
 	if mediaType := ctx.MediaType(); mediaType != "" && mediaType != "application/x-www-form-urlencoded" {
-		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type").WithStatusCode(http.StatusUnsupportedMediaType))
+		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type"))
 		return
 	}
 
@@ -42,7 +42,7 @@ func handleCreate(ctx oidc.Context) {
 
 func handleIntrospection(ctx oidc.Context) {
 	if mediaType := ctx.MediaType(); mediaType != "" && mediaType != "application/x-www-form-urlencoded" {
-		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type").WithStatusCode(http.StatusUnsupportedMediaType))
+		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type"))
 		return
 	}
 
@@ -60,7 +60,7 @@ func handleIntrospection(ctx oidc.Context) {
 
 func handleRevocation(ctx oidc.Context) {
 	if mediaType := ctx.MediaType(); mediaType != "" && mediaType != "application/x-www-form-urlencoded" {
-		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type").WithStatusCode(http.StatusUnsupportedMediaType))
+		ctx.WriteError(goidc.NewError(goidc.ErrorCodeInvalidRequest, "invalid content type"))
 		return
 	}
 

--- a/internal/token/refresh_token.go
+++ b/internal/token/refresh_token.go
@@ -23,7 +23,7 @@ func generateRefreshTokenGrant(ctx oidc.Context, req request) (response, error) 
 
 	grant, err := ctx.GrantByRefreshToken(req.refreshToken)
 	if err != nil {
-		return response{}, goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid refresh_token", err)
+		return response{}, goidc.WrapError(goidc.ErrorCodeInvalidGrant, "invalid refresh_token", err)
 	}
 
 	if err = validateRefreshTokenGrantRequest(ctx, req, c, grant); err != nil {

--- a/internal/token/refresh_token_test.go
+++ b/internal/token/refresh_token_test.go
@@ -457,7 +457,7 @@ func TestGenerateGrant_RefreshTokenGrant_InvalidRefreshToken(t *testing.T) {
 
 	req := request{
 		grantType:    goidc.GrantRefreshToken,
-		refreshToken: "nonexistent_token",
+		refreshToken: "invalid_refresh_token",
 	}
 
 	// When.
@@ -472,8 +472,8 @@ func TestGenerateGrant_RefreshTokenGrant_InvalidRefreshToken(t *testing.T) {
 	if !errors.As(err, &oidcErr) {
 		t.Fatalf("expected goidc.Error, got %v", err)
 	}
-	if oidcErr.Code != goidc.ErrorCodeInvalidRequest {
-		t.Errorf("Code = %s, want %s", oidcErr.Code, goidc.ErrorCodeInvalidRequest)
+	if oidcErr.Code != goidc.ErrorCodeInvalidGrant {
+		t.Errorf("Code = %s, want %s", oidcErr.Code, goidc.ErrorCodeInvalidGrant)
 	}
 }
 


### PR DESCRIPTION
 Per RFC 6749 §5.2, error 'invalid_grant' for invalid, expired, or revoked grants. Using 'invalid_request' for an unrecognized refresh token is incorrect.

Remove `WithStatusCode(415)` from content type validation
RFC 6749 §5.2 specifies error responses use HTTP 400 (or 401 for client auth failures).