### PR TITLE
fix(userinfo): return invalid_token for inactive tokens 

### DIFF
--- a/internal/userinfo/util.go
+++ b/internal/userinfo/util.go
@@ -21,7 +21,11 @@ func handleUserInfoRequest(ctx oidc.Context) (response, error) {
 
 	tokenInfo, err := token.IntrospectionInfo(ctx, accessToken)
 	if err != nil {
-		return response{}, goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid token", err)
+		return response{}, goidc.WrapError(goidc.ErrorCodeInvalidToken, "invalid token", err)
+	}
+
+	if !tokenInfo.IsActive {
+		return response{}, goidc.NewError(goidc.ErrorCodeInvalidToken, "invalid token")
 	}
 
 	if !strutil.ContainsOpenID(tokenInfo.Scopes) {

--- a/internal/userinfo/util_test.go
+++ b/internal/userinfo/util_test.go
@@ -227,8 +227,9 @@ func TestHandleUserInfoRequest_ExpiredToken(t *testing.T) {
 		t.Fatalf("expected goidc.Error, got %v", err)
 	}
 
-	if oidcErr.Code != goidc.ErrorCodeAccessDenied {
-		t.Errorf("Code = %s, want %s", oidcErr.Code, goidc.ErrorCodeAccessDenied)
+	// RFC 6750 §3.1: inactive/expired tokens return invalid_token (401).
+	if oidcErr.Code != goidc.ErrorCodeInvalidToken {
+		t.Errorf("Code = %s, want %s", oidcErr.Code, goidc.ErrorCodeInvalidToken)
 	}
 }
 


### PR DESCRIPTION
RFC 6750 §3.1 requires the 'invalid_token' error code with a 401 status for expired or inactive access tokens at protected-resource endpoints.

Userinfo endpoint returned ErrorCodeInvalidRequest or ErrorCodeAccessDenied, which are incorrect per the specification. Also add an explicit `!IsActive` check so that expired tokens that are successfully looked up still produce the correct error.