### PR TITLE
feat(introspection): add username claim per RFC 7662 §2.2

### DIFF
--- a/internal/authorize/authorize.go
+++ b/internal/authorize/authorize.go
@@ -274,6 +274,7 @@ func finishFlow(ctx oidc.Context, as *goidc.AuthnSession) error {
 		grant, err := token.NewGrant(ctx, c, token.GrantOptions{
 			Type:        goidc.GrantImplicit,
 			Subject:     as.Subject,
+			Username:    as.Username,
 			ClientID:    as.ClientID,
 			Scopes:      as.GrantedScopes,
 			Nonce:       as.Nonce,

--- a/internal/token/auth_code.go
+++ b/internal/token/auth_code.go
@@ -46,6 +46,7 @@ func generateAuthCodeGrant(ctx oidc.Context, req request) (response, error) {
 		AuthCode:             as.AuthCode,
 		Type:                 goidc.GrantAuthorizationCode,
 		Subject:              as.Subject,
+		Username:             as.Username,
 		ClientID:             as.ClientID,
 		Scopes:               as.GrantedScopes,
 		AuthDetails:          as.GrantedAuthDetails,

--- a/internal/token/auth_code_test.go
+++ b/internal/token/auth_code_test.go
@@ -96,6 +96,36 @@ func TestGenerateGrant_AuthorizationCodeGrant(t *testing.T) {
 	}
 }
 
+func TestGenerateGrant_AuthorizationCodeGrant_PropagatesUsername(t *testing.T) {
+
+	// Given.
+	ctx, client, session := setUpAuthzCodeGrant(t)
+	session.Username = "alice"
+	if err := ctx.SaveAuthnSession(session); err != nil {
+		t.Fatalf("error while updating the session: %v", err)
+	}
+
+	req := request{
+		grantType:   goidc.GrantAuthorizationCode,
+		redirectURI: client.RedirectURIs[0],
+		code:        session.AuthCode,
+	}
+
+	// When.
+	if _, err := generateGrant(ctx, req); err != nil {
+		t.Fatalf("error generating the authorization code grant: %v", err)
+	}
+
+	// Then.
+	grants := oidctest.Grants(t, ctx)
+	if len(grants) != 1 {
+		t.Fatalf("len(grants) = %d, want 1", len(grants))
+	}
+	if grants[0].Username != "alice" {
+		t.Errorf("grant.Username = %q, want %q", grants[0].Username, "alice")
+	}
+}
+
 func TestGenerateGrant_AuthorizationCodeGrant_AuthDetails(t *testing.T) {
 
 	// Given.

--- a/internal/token/ciba.go
+++ b/internal/token/ciba.go
@@ -53,6 +53,7 @@ func NotifyCIBAGrant(ctx oidc.Context, authReqID string) error {
 	grant, err := NewGrant(ctx, c, GrantOptions{
 		Type:                 goidc.GrantCIBA,
 		Subject:              as.Subject,
+		Username:             as.Username,
 		ClientID:             as.ClientID,
 		Scopes:               as.GrantedScopes,
 		AuthDetails:          as.GrantedAuthDetails,
@@ -197,6 +198,7 @@ func generateCIBAGrant(ctx oidc.Context, req request) (response, error) {
 	grant, err := NewGrant(ctx, c, GrantOptions{
 		Type:                 goidc.GrantCIBA,
 		Subject:              as.Subject,
+		Username:             as.Username,
 		ClientID:             as.ClientID,
 		Scopes:               as.GrantedScopes,
 		AuthDetails:          as.GrantedAuthDetails,

--- a/internal/token/ciba_test.go
+++ b/internal/token/ciba_test.go
@@ -93,6 +93,35 @@ func TestGenerateGrant_CIBAGrant(t *testing.T) {
 	}
 }
 
+func TestGenerateGrant_CIBAGrant_PropagatesUsername(t *testing.T) {
+
+	// Given.
+	ctx, _, session := setUpCIBAGrant(t)
+	session.Username = "alice"
+	if err := ctx.SaveAuthnSession(session); err != nil {
+		t.Fatalf("error while updating the session: %v", err)
+	}
+
+	req := request{
+		grantType: goidc.GrantCIBA,
+		authReqID: session.CIBAAuthID,
+	}
+
+	// When.
+	if _, err := generateGrant(ctx, req); err != nil {
+		t.Fatalf("error generating the grant: %v", err)
+	}
+
+	// Then.
+	grants := oidctest.Grants(t, ctx)
+	if len(grants) != 1 {
+		t.Fatalf("len(grants) = %d, want 1", len(grants))
+	}
+	if grants[0].Username != "alice" {
+		t.Errorf("grant.Username = %q, want %q", grants[0].Username, "alice")
+	}
+}
+
 // TestGenerateGrant_CIBAGrant_AuthPending validates that when a CIBA poll request
 // is made to the token endpoint for an ongoing authentication process, the
 // "authorization_pending" error is returned as expected.

--- a/internal/token/introspection.go
+++ b/internal/token/introspection.go
@@ -134,6 +134,7 @@ func accessTokenInfo(ctx oidc.Context, accessToken string) (goidc.TokenInfo, err
 		IsActive:           true,
 		Issuer:             ctx.Issuer(),
 		Subject:            tkn.Subject,
+		Username:           grant.Username,
 		Type:               tkn.Type,
 		Scopes:             tkn.Scopes,
 		AuthDetails:        tkn.AuthDetails,

--- a/internal/token/introspection_test.go
+++ b/internal/token/introspection_test.go
@@ -77,6 +77,43 @@ func TestIntrospect_OpaqueToken(t *testing.T) {
 	}
 }
 
+func TestIntrospect_OpaqueToken_IncludesUsername(t *testing.T) {
+	ctx, client := setUpIntrospection(t)
+
+	accessToken := "opaque_token"
+	now := timeutil.TimestampNow()
+	tokenEntity := &goidc.Token{
+		ID:                 accessToken,
+		GrantID:            "random_grant_id",
+		ClientID:           client.ID,
+		CreatedAtTimestamp: now,
+		ExpiresAtTimestamp: now + 60,
+		Scopes:             goidc.ScopeOpenID.ID,
+		Type:               goidc.TokenTypeBearer,
+	}
+	_ = ctx.SaveGrant(&goidc.Grant{
+		ID:                 tokenEntity.GrantID,
+		CreatedAtTimestamp: now,
+		ClientID:           client.ID,
+		Username:           "alice",
+	})
+	_ = ctx.SaveToken(tokenEntity)
+
+	tokenReq := queryRequest{
+		token: accessToken,
+	}
+
+	tokenInfo, err := introspect(ctx, tokenReq)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tokenInfo.Username != "alice" {
+		t.Errorf("Username = %q, want %q", tokenInfo.Username, "alice")
+	}
+}
+
 func TestIntrospect_RefreshToken(t *testing.T) {
 	// Given.
 	ctx, client := setUpIntrospection(t)

--- a/internal/token/model.go
+++ b/internal/token/model.go
@@ -15,6 +15,7 @@ type GrantOptions struct {
 	PreAuthCode          string
 	Type                 goidc.GrantType
 	Subject              string
+	Username             string
 	ClientID             string
 	Scopes               string
 	AuthDetails          []goidc.AuthDetail
@@ -32,6 +33,7 @@ func NewGrant(ctx oidc.Context, c *goidc.Client, opts GrantOptions) (*goidc.Gran
 		PreAuthCode:        opts.PreAuthCode,
 		Type:               opts.Type,
 		Subject:            opts.Subject,
+		Username:           opts.Username,
 		ClientID:           opts.ClientID,
 		Scopes:             opts.Scopes,
 		Nonce:              opts.Nonce,

--- a/pkg/goidc/authn_session.go
+++ b/pkg/goidc/authn_session.go
@@ -36,7 +36,11 @@ type AuthnSession struct {
 	// Subject is the user identifier.
 	//
 	// This value must be informed during the authentication flow.
-	Subject  string `json:"sub"`
+	Subject string `json:"sub"`
+	// [RFC 7662 §2.2] Username is a human-readable identifier for the resource owner.
+	// When set during the authentication flow, it is propagated to the resulting
+	// grant and returned in the introspection response.
+	Username string `json:"username,omitempty"`
 	ClientID string `json:"client_id"`
 	// PushedAuthReqID is the id generated during /par used to fetch the session
 	// during calls to /authorize.

--- a/pkg/goidc/grant.go
+++ b/pkg/goidc/grant.go
@@ -39,6 +39,9 @@ type Grant struct {
 	// Subject is the ID of the user or client associated with the grant.
 	Subject  string `json:"sub"`
 	ClientID string `json:"client_id"`
+	// Username is a human-readable identifier for the resource owner (RFC 7662 §2.2).
+	// Populated via HandleGrantFunc or by resource-owner password grant.
+	Username string `json:"username,omitempty"`
 
 	Scopes      string       `json:"scopes"`
 	AuthDetails []AuthDetail `json:"auth_details,omitempty"`

--- a/pkg/goidc/grant.go
+++ b/pkg/goidc/grant.go
@@ -39,7 +39,7 @@ type Grant struct {
 	// Subject is the ID of the user or client associated with the grant.
 	Subject  string `json:"sub"`
 	ClientID string `json:"client_id"`
-	// Username is a human-readable identifier for the resource owner (RFC 7662 §2.2).
+	// [RFC 7662 §2.2] Username is a human-readable identifier for the resource owner.
 	// Populated via HandleGrantFunc or by resource-owner password grant.
 	Username string `json:"username,omitempty"`
 

--- a/pkg/goidc/model.go
+++ b/pkg/goidc/model.go
@@ -450,9 +450,8 @@ type TokenInfo struct {
 	ResourceAudiences Resources    `json:"aud,omitempty"`
 	ClientID          string       `json:"client_id,omitempty"`
 	Subject           string       `json:"sub,omitempty"`
-	// Username is a human-readable identifier for the resource owner (RFC 7662 §2.2).
+	// [RFC 7662 §2.2] Username is a human-readable identifier for the resource owner.
 	// Populate via AdditionalTokenClaims if the authorization server can resolve it.
-	// TODO: Fill it with grant.Username.
 	Username           string             `json:"username,omitempty"`
 	Issuer             string             `json:"iss,omitempty"`
 	IssuedAtTimestamp  int                `json:"iat,omitempty"`


### PR DESCRIPTION
Add a Username field to Grant so it can be populated during grant creation (e.g. by resource-owner password or HandleGrantFunc) and returned in the introspection response as the optional 'username' claim defined by RFC 7662 §2.2.