### PR TITLE
feat: add external client resolution and RFC 8414 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A configurable OpenID Connect Provider for Go.
 * [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
 * [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
 * [`RFC 6749` - The OAuth 2.0 Authorization Framework](https://www.rfc-editor.org/rfc/rfc6749.html)
+* [`RFC 8414` - OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414.html)
 * [`RFC 9068` - JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://www.rfc-editor.org/rfc/rfc9068.html)
 * [OpenID Connect Dynamic Client Registration 1.0](https://openid.net/specs/openid-connect-registration-1_0.html)
 * [`RFC 7591` - OAuth 2.0 Dynamic Client Registration Protocol (DCR)](https://www.rfc-editor.org/rfc/rfc7591.html)
@@ -906,6 +907,27 @@ op, _ := provider.New(
   ...,
 )
 ```
+
+## Client resolution
+
+Use `provider.WithClientResolver` when clients live in an external store but
+must not be allowed to register themselves:
+
+```go
+op, _ := provider.New(
+  ...,
+  provider.WithClientResolver(func(ctx context.Context, id string) (*goidc.Client, error) {
+    return clientStore.Client(ctx, id)
+  }),
+)
+```
+
+The resolver is called for every lookup and must return `goidc.ErrNotFound`
+only for unknown clients. Other errors remain operational errors. Resolved
+clients and their referenced JWKS are not cached, so disablement and key
+rotation take effect on the next request. Static clients may be configured as
+well and take precedence. A resolver cannot be combined with DCR or OpenID
+Federation, which provide their own dynamic client sources.
 
 ## [Dynamic Client Registration (DCR)](https://www.rfc-editor.org/rfc/rfc7591.html)
 

--- a/internal/authorize/authorize.go
+++ b/internal/authorize/authorize.go
@@ -53,6 +53,9 @@ func initAuth(ctx oidc.Context, req request) error {
 		return c, nil
 	}()
 	if err != nil {
+		if ctx.ResolveClientFunc != nil && !errors.Is(err, goidc.ErrNotFound) {
+			return fmt.Errorf("could not load the client: %w", err)
+		}
 		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client_id", fmt.Errorf("could not load the client: %w", err))
 	}
 

--- a/internal/authorize/authorize_test.go
+++ b/internal/authorize/authorize_test.go
@@ -1312,6 +1312,23 @@ func TestContinueAuthentication(t *testing.T) {
 	}
 }
 
+func TestInitAuthPropagatesClientResolverOperationalFailure(t *testing.T) {
+	resolverFailure := errors.New("client store unavailable")
+	ctx := oidctest.NewContext(t)
+	ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+		return nil, resolverFailure
+	}
+
+	err := initAuth(ctx, request{ClientID: "client"})
+	if !errors.Is(err, resolverFailure) {
+		t.Fatalf("initAuth() error = %v, want resolver failure", err)
+	}
+	var oidcErr goidc.Error
+	if errors.As(err, &oidcErr) {
+		t.Fatalf("initAuth() mapped operational failure to protocol error %s", oidcErr.Code)
+	}
+}
+
 func setUpAuth(t *testing.T) (oidc.Context, *goidc.Client) {
 	t.Helper()
 

--- a/internal/client/authn_test.go
+++ b/internal/client/authn_test.go
@@ -1217,6 +1217,25 @@ func TestAuthenticated(t *testing.T) {
 	}
 }
 
+func TestAuthenticated_PreservesClientResolverOperationalError(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	ctx.Request.PostForm = map[string][]string{"client_id": {"client"}}
+	resolverErr := errors.New("client store unavailable")
+	ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+		return nil, resolverErr
+	}
+
+	_, err := client.Authenticated(ctx, client.AuthnContextToken)
+
+	if !errors.Is(err, resolverErr) {
+		t.Fatalf("Authenticated() error = %v, want wrapped %v", err, resolverErr)
+	}
+	var oidcErr goidc.Error
+	if errors.As(err, &oidcErr) {
+		t.Fatalf("operational error was converted to protocol error %q", oidcErr.Code)
+	}
+}
+
 func TestExtractID(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/client/util.go
+++ b/internal/client/util.go
@@ -20,6 +20,20 @@ func Client(ctx oidc.Context, id string) (*goidc.Client, error) {
 		}
 	}
 
+	if ctx.ResolveClientFunc != nil {
+		c, err := ctx.ResolveClient(id)
+		if err != nil {
+			return nil, err
+		}
+		if c == nil {
+			return nil, errors.New("client resolver returned a nil client")
+		}
+		if c.ID != id {
+			return nil, fmt.Errorf("client resolver returned client %q for %q", c.ID, id)
+		}
+		return c, nil
+	}
+
 	if ctx.OpenIDFedEnabled && strutil.IsURL(id) {
 		return ctx.OpenIDFedClient(id)
 	}
@@ -69,18 +83,27 @@ func JWKByAlg(ctx oidc.Context, c *goidc.Client, alg string) (goidc.JSONWebKey, 
 //  2. From jwks_uri as a fallback.
 //  3. Directly from the jwks attribute if present.
 //
-// It also caches the keys if they are fetched.
+// Fetched keys are cached unless the client came from ResolveClientFunc. The
+// latter is deliberately re-fetched so key rotation takes effect immediately.
 func JWKS(ctx oidc.Context, c *goidc.Client) (*goidc.JSONWebKeySet, error) {
-	if jwks := c.CachedJWKS(); jwks != nil {
-		return jwks, nil
+	cacheEnabled := clientJWKSCacheEnabled(ctx, c)
+	if cacheEnabled {
+		if jwks := c.CachedJWKS(); jwks != nil {
+			return jwks, nil
+		}
 	}
 
 	if c.SignedJWKSURI != "" {
+		if !ctx.OpenIDFedEnabled || ctx.OpenIDFedEntityJWKSFunc == nil {
+			return nil, errors.New("signed_jwks_uri requires OpenID Federation")
+		}
 		jwks, err := fetchSignedJWKS(ctx, c)
 		if err != nil {
 			return nil, err
 		}
-		c.CacheJWKS(jwks)
+		if cacheEnabled {
+			c.CacheJWKS(jwks)
+		}
 		return jwks, nil
 	}
 
@@ -89,7 +112,9 @@ func JWKS(ctx oidc.Context, c *goidc.Client) (*goidc.JSONWebKeySet, error) {
 		if err != nil {
 			return nil, err
 		}
-		c.CacheJWKS(jwks)
+		if cacheEnabled {
+			c.CacheJWKS(jwks)
+		}
 		return jwks, nil
 	}
 
@@ -97,6 +122,18 @@ func JWKS(ctx oidc.Context, c *goidc.Client) (*goidc.JSONWebKeySet, error) {
 		return nil, errors.New("the client jwks was informed neither by value nor by reference")
 	}
 	return c.JWKS, nil
+}
+
+func clientJWKSCacheEnabled(ctx oidc.Context, c *goidc.Client) bool {
+	if ctx.ResolveClientFunc == nil {
+		return true
+	}
+	for _, staticClient := range ctx.StaticClients {
+		if staticClient == c {
+			return true
+		}
+	}
+	return false
 }
 
 func fetchJWKS(ctx oidc.Context, c *goidc.Client) (*goidc.JSONWebKeySet, error) {

--- a/internal/client/util_test.go
+++ b/internal/client/util_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,12 +17,61 @@ import (
 )
 
 func TestClient(t *testing.T) {
+	resolverErr := errors.New("client store unavailable")
 	tests := []struct {
 		name         string
 		setup        func(*testing.T) (oidc.Context, string)
 		wantClientID string
+		wantSecret   string
 		wantErr      error
 	}{
+		{
+			name: "resolved client",
+			setup: func(t *testing.T) (oidc.Context, string) {
+				ctx := oidctest.NewContext(t)
+				ctx.ResolveClientFunc = func(_ context.Context, id string) (*goidc.Client, error) {
+					return &goidc.Client{ID: id}, nil
+				}
+				return ctx, "resolved_client"
+			},
+			wantClientID: "resolved_client",
+		},
+		{
+			name: "static client takes precedence over resolver",
+			setup: func(t *testing.T) (oidc.Context, string) {
+				ctx := oidctest.NewContext(t)
+				staticClient := &goidc.Client{ID: "shared_client", Secret: "static"}
+				ctx.StaticClients = append(ctx.StaticClients, staticClient)
+				ctx.ResolveClientFunc = func(_ context.Context, id string) (*goidc.Client, error) {
+					return &goidc.Client{ID: id, Secret: "resolved"}, nil
+				}
+				return ctx, staticClient.ID
+			},
+			wantClientID: "shared_client",
+			wantSecret:   "static",
+		},
+		{
+			name: "resolver not found",
+			setup: func(t *testing.T) (oidc.Context, string) {
+				ctx := oidctest.NewContext(t)
+				ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+					return nil, fmt.Errorf("lookup failed: %w", goidc.ErrNotFound)
+				}
+				return ctx, "missing_client"
+			},
+			wantErr: goidc.ErrNotFound,
+		},
+		{
+			name: "resolver operational error",
+			setup: func(t *testing.T) (oidc.Context, string) {
+				ctx := oidctest.NewContext(t)
+				ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+					return nil, resolverErr
+				}
+				return ctx, "client"
+			},
+			wantErr: resolverErr,
+		},
 		{
 			name: "static client",
 			setup: func(t *testing.T) (oidc.Context, string) {
@@ -153,7 +204,100 @@ func TestClient(t *testing.T) {
 			if got.ID != test.wantClientID {
 				t.Fatalf("client ID = %q, want %q", got.ID, test.wantClientID)
 			}
+			if test.wantSecret != "" && got.Secret != test.wantSecret {
+				t.Fatalf("client secret = %q, want %q", got.Secret, test.wantSecret)
+			}
 		})
+	}
+}
+
+func TestClient_ResolverIsConsultedForEveryLookup(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	clientID := "client"
+	current := &goidc.Client{ID: clientID, Secret: "first"}
+	calls := 0
+	ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+		calls++
+		if current == nil {
+			return nil, goidc.ErrNotFound
+		}
+		copy := *current
+		return &copy, nil
+	}
+
+	first, err := Client(ctx, clientID)
+	if err != nil {
+		t.Fatalf("first Client() error = %v", err)
+	}
+	if first.Secret != "first" {
+		t.Fatalf("first secret = %q, want %q", first.Secret, "first")
+	}
+
+	current = &goidc.Client{ID: clientID, Secret: "rotated"}
+	second, err := Client(ctx, clientID)
+	if err != nil {
+		t.Fatalf("second Client() error = %v", err)
+	}
+	if second.Secret != "rotated" {
+		t.Fatalf("second secret = %q, want %q", second.Secret, "rotated")
+	}
+
+	current = nil
+	if _, err := Client(ctx, clientID); !errors.Is(err, goidc.ErrNotFound) {
+		t.Fatalf("disabled Client() error = %v, want %v", err, goidc.ErrNotFound)
+	}
+	if calls != 3 {
+		t.Fatalf("resolver calls = %d, want 3", calls)
+	}
+}
+
+func TestClientRejectsInvalidResolverResults(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		resolver goidc.ResolveClientFunc
+		want     string
+	}{
+		{
+			name: "nil client",
+			resolver: func(context.Context, string) (*goidc.Client, error) {
+				return nil, nil
+			},
+			want: "nil client",
+		},
+		{
+			name: "mismatched client identifier",
+			resolver: func(context.Context, string) (*goidc.Client, error) {
+				return &goidc.Client{ID: "different_client"}, nil
+			},
+			want: "different_client",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			ctx.ResolveClientFunc = test.resolver
+			if _, err := Client(ctx, "requested_client"); err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Client() error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestJWKSRejectsSignedJWKSURIWithoutFederation(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+		return &goidc.Client{
+			ID: "resolved_client",
+			ClientMeta: goidc.ClientMeta{
+				SignedJWKSURI: "https://client.example.com/signed-jwks",
+			},
+		}, nil
+	}
+	resolved, err := Client(ctx, "resolved_client")
+	if err != nil {
+		t.Fatalf("Client() error = %v", err)
+	}
+	if _, err := JWKS(ctx, resolved); err == nil || !strings.Contains(err.Error(), "OpenID Federation") {
+		t.Fatalf("JWKS() error = %v, want OpenID Federation requirement", err)
 	}
 }
 
@@ -195,6 +339,61 @@ func TestFetchPublicJWKS(t *testing.T) {
 		if c.CachedJWKS() == nil {
 			t.Errorf("the jwks was not cached. attempt %d", i+1)
 		}
+	}
+}
+
+func TestJWKS_DynamicallyResolvedClientIsNotCached(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	firstPrivateKey := oidctest.PrivatePS256JWK(t, "first_key", goidc.KeyUsageSignature)
+	rotatedPrivateKey := oidctest.PrivatePS256JWK(t, "rotated_key", goidc.KeyUsageSignature)
+	firstKey := firstPrivateKey.Public()
+	rotatedKey := rotatedPrivateKey.Public()
+	currentKey := firstKey
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if err := json.NewEncoder(w).Encode(goidc.JSONWebKeySet{Keys: []goidc.JSONWebKey{currentKey}}); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer server.Close()
+
+	resolvedClient := &goidc.Client{
+		ID: "client",
+		ClientMeta: goidc.ClientMeta{
+			JWKSURI: server.URL,
+		},
+	}
+	ctx.ResolveClientFunc = func(context.Context, string) (*goidc.Client, error) {
+		return resolvedClient, nil
+	}
+
+	first, err := Client(ctx, resolvedClient.ID)
+	if err != nil {
+		t.Fatalf("first Client() error = %v", err)
+	}
+	firstJWKS, err := JWKS(ctx, first)
+	if err != nil {
+		t.Fatalf("first JWKS() error = %v", err)
+	}
+	if firstJWKS.Keys[0].KeyID != firstKey.KeyID {
+		t.Fatalf("first key ID = %q, want %q", firstJWKS.Keys[0].KeyID, firstKey.KeyID)
+	}
+
+	currentKey = rotatedKey
+	second, err := Client(ctx, resolvedClient.ID)
+	if err != nil {
+		t.Fatalf("second Client() error = %v", err)
+	}
+	secondJWKS, err := JWKS(ctx, second)
+	if err != nil {
+		t.Fatalf("second JWKS() error = %v", err)
+	}
+	if secondJWKS.Keys[0].KeyID != rotatedKey.KeyID {
+		t.Fatalf("rotated key ID = %q, want %q", secondJWKS.Keys[0].KeyID, rotatedKey.KeyID)
+	}
+	if requests != 2 {
+		t.Fatalf("JWKS requests = %d, want 2", requests)
 	}
 }
 

--- a/internal/discovery/api.go
+++ b/internal/discovery/api.go
@@ -11,8 +11,10 @@ import (
 
 func RegisterHandlers(router *http.ServeMux, config *oidc.Configuration, middlewares ...goidc.MiddlewareFunc) {
 	issuer, _ := url.Parse(config.Host)
-	router.Handle("GET /.well-known/openid-configuration"+strings.TrimSuffix(issuer.Path, "/"),
-		goidc.ApplyMiddlewares(oidc.Handler(config, handleWellKnown), middlewares...))
+	issuerPath := strings.TrimSuffix(issuer.Path, "/")
+	metadataHandler := goidc.ApplyMiddlewares(oidc.Handler(config, handleWellKnown), middlewares...)
+	router.Handle("GET "+issuerPath+"/.well-known/openid-configuration", metadataHandler)
+	router.Handle("GET /.well-known/oauth-authorization-server"+issuerPath, metadataHandler)
 
 	router.Handle("GET "+config.EndpointPrefix+config.JWKSEndpoint,
 		goidc.ApplyMiddlewares(oidc.Handler(config, handleJWKS), middlewares...))

--- a/internal/discovery/api_test.go
+++ b/internal/discovery/api_test.go
@@ -1,0 +1,80 @@
+package discovery
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luikyv/go-oidc/internal/oidctest"
+)
+
+func TestRegisterHandlers_AuthorizationServerMetadata(t *testing.T) {
+	tests := []struct {
+		name   string
+		issuer string
+		paths  []string
+	}{
+		{
+			name:   "issuer without path",
+			issuer: "https://example.com",
+			paths: []string{
+				"/.well-known/oauth-authorization-server",
+				"/.well-known/openid-configuration",
+			},
+		},
+		{
+			name:   "issuer with path",
+			issuer: "https://example.com/tenant/issuer",
+			paths: []string{
+				"/.well-known/oauth-authorization-server/tenant/issuer",
+				"/tenant/issuer/.well-known/openid-configuration",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			ctx.Host = test.issuer
+			ctx.DCREnabled = false
+			mux := http.NewServeMux()
+			RegisterHandlers(mux, ctx.Configuration)
+
+			for _, path := range test.paths {
+				recorder := httptest.NewRecorder()
+				mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+
+				if recorder.Code != http.StatusOK {
+					t.Fatalf("GET %s status = %d, want %d", path, recorder.Code, http.StatusOK)
+				}
+				var metadata map[string]any
+				if err := json.Unmarshal(recorder.Body.Bytes(), &metadata); err != nil {
+					t.Fatalf("decode metadata from %s: %v", path, err)
+				}
+				if metadata["issuer"] != test.issuer {
+					t.Fatalf("GET %s issuer = %v, want %q", path, metadata["issuer"], test.issuer)
+				}
+				if _, advertised := metadata["registration_endpoint"]; advertised {
+					t.Fatalf("GET %s advertises registration_endpoint while DCR is disabled", path)
+				}
+			}
+		})
+	}
+}
+
+func TestRegisterHandlersRejectsNonStandardPathBasedOIDCMetadataRoute(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	ctx.Host = "https://example.com/tenant/issuer"
+	mux := http.NewServeMux()
+	RegisterHandlers(mux, ctx.Configuration)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration/tenant/issuer", nil),
+	)
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("non-standard OIDC metadata route status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -53,6 +53,7 @@ type Configuration struct {
 	SubIdentifierTypes       []goidc.SubIdentifierType
 	PairwiseSubjectFunc      goidc.PairwiseSubjectFunc
 	StaticClients            []*goidc.Client
+	ResolveClientFunc        goidc.ResolveClientFunc
 	// IssuerRespParamEnabled indicates if the "iss" parameter will be
 	// returned when redirecting the user back to the client application.
 	IssuerRespParamEnabled bool

--- a/internal/oidc/context.go
+++ b/internal/oidc/context.go
@@ -105,6 +105,10 @@ func (ctx Context) DCRDeleteClient(id string) error {
 	return ctx.DCRManager.DeleteClient(ctx, id)
 }
 
+func (ctx Context) ResolveClient(id string) (*goidc.Client, error) {
+	return ctx.ResolveClientFunc(ctx, id)
+}
+
 func (ctx Context) ValidateInitalAccessToken(token string) error {
 	return ctx.DCRValidateInitialTokenFunc(ctx, token)
 }

--- a/pkg/goidc/model.go
+++ b/pkg/goidc/model.go
@@ -121,6 +121,17 @@ type DCRManager interface {
 	DeleteClient(context.Context, string) error
 }
 
+// ResolveClientFunc resolves the current client configuration by identifier.
+// It must return [ErrNotFound] only when the client does not exist. Other
+// errors are treated as operational failures and returned to the caller.
+//
+// The provider invokes this function for every client lookup and does not
+// cache the returned client or its JWKS. Implementations should therefore
+// return the latest client state, including key rotations and disablement.
+// The function may be called concurrently and must return a snapshot that is
+// safe for the provider to read for the duration of the request.
+type ResolveClientFunc func(context.Context, string) (*Client, error)
+
 // OpenIDFedManager stores OpenID Federation clients.
 type OpenIDFedManager interface {
 	SaveClient(context.Context, *Client) error

--- a/pkg/provider/option.go
+++ b/pkg/provider/option.go
@@ -1699,6 +1699,24 @@ func WithStaticClients(cs ...*goidc.Client) Option {
 	}
 }
 
+// WithClientResolver configures a dynamic source of client metadata without
+// enabling Dynamic Client Registration. The resolver is invoked for every
+// client lookup, after static clients are checked, and its results are not
+// cached by the provider.
+//
+// A client resolver cannot be combined with Dynamic Client Registration or
+// OpenID Federation because those features provide their own dynamic client
+// sources. Static clients may be combined with a resolver and take precedence.
+func WithClientResolver(f goidc.ResolveClientFunc) Option {
+	return func(p *Provider) error {
+		if f == nil {
+			return errors.New("client resolver cannot be nil")
+		}
+		p.config.ResolveClientFunc = f
+		return nil
+	}
+}
+
 // ── OpenID Federation ─────────────────────────────────────────────────────────
 
 // OpenIDFedOption is an optional configuration for OpenID Federation.

--- a/pkg/provider/option_test.go
+++ b/pkg/provider/option_test.go
@@ -1807,6 +1807,35 @@ func TestWithStaticClients(t *testing.T) {
 	}
 }
 
+func TestWithClientResolver(t *testing.T) {
+	p := &Provider{config: oidc.Configuration{}}
+	resolver := func(context.Context, string) (*goidc.Client, error) {
+		return nil, goidc.ErrNotFound
+	}
+
+	err := WithClientResolver(resolver)(p)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.config.ResolveClientFunc == nil {
+		t.Fatal("ResolveClientFunc must be set")
+	}
+	if p.config.DCREnabled {
+		t.Fatal("client resolver must not enable DCR")
+	}
+}
+
+func TestWithClientResolver_Nil(t *testing.T) {
+	p := &Provider{config: oidc.Configuration{}}
+
+	err := WithClientResolver(nil)(p)
+
+	if err == nil {
+		t.Fatal("WithClientResolver(nil) error = nil, want non-nil")
+	}
+}
+
 func TestWithAuthPolicies(t *testing.T) {
 	p := &Provider{}
 	policy := goidc.AuthnPolicy{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -92,6 +92,14 @@ func New(cfg Config, opts ...Option) (*Provider, error) {
 		}
 	}
 
+	if op.config.ResolveClientFunc != nil && op.config.DCREnabled {
+		return nil, errors.New("client resolver cannot be combined with dynamic client registration")
+	}
+
+	if op.config.ResolveClientFunc != nil && op.config.OpenIDFedEnabled {
+		return nil, errors.New("client resolver cannot be combined with OpenID Federation")
+	}
+
 	if op.config.AuthnMethodDefault != "" && !slices.Contains(op.config.AuthnMethods, op.config.AuthnMethodDefault) {
 		return nil, fmt.Errorf("default authn method %q is not among the enabled authn methods", op.config.AuthnMethodDefault)
 	}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -359,6 +360,31 @@ func TestNew_ValidationErrors(t *testing.T) {
 			wantErr: "dcr secret rotation requires a secret-based token authentication method",
 		},
 		{
+			name: "client resolver and dcr are mutually exclusive",
+			opts: []Option{
+				WithClientResolver(func(context.Context, string) (*goidc.Client, error) {
+					return nil, goidc.ErrNotFound
+				}),
+				WithDCR(nil),
+			},
+			wantErr: "client resolver cannot be combined with dynamic client registration",
+		},
+		{
+			name: "client resolver and federation are mutually exclusive",
+			opts: []Option{
+				WithClientResolver(func(context.Context, string) (*goidc.Client, error) {
+					return nil, goidc.ErrNotFound
+				}),
+				WithOpenIDFederation(OpenIDFedConfig{
+					JWKSFunc:       jwksFunc,
+					SigAlg:         goidc.SigAlgRS256,
+					AuthorityHints: []string{"https://authority.example.com"},
+					TrustedAnchors: []string{"https://trust-anchor.example.com"},
+				}),
+			},
+			wantErr: "client resolver cannot be combined with OpenID Federation",
+		},
+		{
 			name: "dc sd-jwt credential configuration requires type",
 			opts: []Option{
 				WithVCI(WithVCISelf([]goidc.VCConfiguration{
@@ -418,6 +444,40 @@ func TestNew_ValidationErrors(t *testing.T) {
 				t.Fatalf("New() error = %q, want %q", got, test.wantErr)
 			}
 		})
+	}
+}
+
+func TestClientResolverDoesNotExposeDynamicRegistration(t *testing.T) {
+	op, err := New(Config{
+		Issuer: "https://example.com",
+		JWKS: func(context.Context) (goidc.JSONWebKeySet, error) {
+			return goidc.JSONWebKeySet{}, nil
+		},
+		IDTokenAlgs: []goidc.SignatureAlgorithm{goidc.SigAlgRS256},
+	}, WithClientResolver(func(context.Context, string) (*goidc.Client, error) {
+		return nil, goidc.ErrNotFound
+	}))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	metadataResponse := httptest.NewRecorder()
+	op.Handler().ServeHTTP(metadataResponse, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil))
+	if metadataResponse.Code != http.StatusOK {
+		t.Fatalf("metadata status = %d, want %d", metadataResponse.Code, http.StatusOK)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(metadataResponse.Body.Bytes(), &metadata); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if _, advertised := metadata["registration_endpoint"]; advertised {
+		t.Fatal("registration_endpoint advertised with only a client resolver configured")
+	}
+
+	registrationResponse := httptest.NewRecorder()
+	op.Handler().ServeHTTP(registrationResponse, httptest.NewRequest(http.MethodPost, defaultEndpointDynamicClient, nil))
+	if registrationResponse.Code != http.StatusNotFound {
+		t.Fatalf("registration status = %d, want %d", registrationResponse.Code, http.StatusNotFound)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an external client resolver for deployments that keep client metadata in their own store without enabling dynamic registration
- resolve the current client snapshot on every lookup, preserve static-client precedence, and avoid caching resolver-owned JWKS
- keep resolver errors operational unless they explicitly wrap goidc.ErrNotFound
- reject incompatible resolver combinations with DCR or OpenID Federation
- expose both OpenID Discovery and RFC 8414 authorization-server metadata at their standards-defined paths

## Security behavior

Resolver results are rejected when nil or when the returned client ID does not match the requested ID. signed_jwks_uri fails safely when Federation is unavailable. Authorization requests preserve resolver-store failures as server errors rather than misclassifying them as unknown clients.

## Verification

- go test ./...
- go test -race ./internal/client ./internal/discovery ./internal/authorize ./pkg/provider
- go vet ./...
- golangci-lint run
- git diff --check

References: RFC 8414 and OpenID Connect Discovery 1.0.
