### PR TITLE
feat: add typed atomic JWT replay consumption

### DIFF
--- a/internal/authorize/ciba.go
+++ b/internal/authorize/ciba.go
@@ -82,10 +82,6 @@ func initBackAuth(ctx oidc.Context, req request) (cibaResponse, error) {
 				return nil, goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid request object", errors.New("claim 'jti' is required in the request object"))
 			}
 
-			if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-				return nil, goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid request object", fmt.Errorf("could not validate the request object jti: %w", err))
-			}
-
 			if err := claims.ValidateWithLeeway(jwt.Expected{
 				Issuer:      c.ID,
 				AnyAudience: []string{ctx.Issuer()},
@@ -94,6 +90,15 @@ func initBackAuth(ctx oidc.Context, req request) (cibaResponse, error) {
 			}
 
 			if err := validateCIBARequest(ctx, requestObject, c); err != nil {
+				return nil, err
+			}
+
+			if err := ctx.ReserveJTI(goidc.JTIUse{
+				ID:        claims.ID,
+				Issuer:    claims.Issuer,
+				Purpose:   goidc.JTIUsePurposeRequestObject,
+				ExpiresAt: claims.Expiry.Time().Add(time.Duration(ctx.JWTLeewayTimeSecs) * time.Second),
+			}, goidc.ErrorCodeInvalidRequest, "invalid request object"); err != nil {
 				return nil, err
 			}
 

--- a/internal/authorize/ciba_test.go
+++ b/internal/authorize/ciba_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -214,11 +215,30 @@ func TestInitBackAuth(t *testing.T) {
 				}
 
 				now := timeutil.TimestampNow()
+				expiresAt := now + 10
+				consumed := false
+				ctx.ConsumeJTIUseFunc = func(_ context.Context, use goidc.JTIUse) error {
+					if use.ID != "random_id" || use.Issuer != client.ID || use.Purpose != goidc.JTIUsePurposeRequestObject {
+						t.Fatalf("JTI use = %#v, want CIBA request-object reservation", use)
+					}
+					wantExpiry := time.Unix(int64(expiresAt+ctx.JWTLeewayTimeSecs), 0).UTC()
+					if !use.ExpiresAt.Equal(wantExpiry) {
+						t.Fatalf("JTI expiry = %v, want %v", use.ExpiresAt, wantExpiry)
+					}
+					consumed = true
+					return nil
+				}
+				ctx.CIBAHandleSessionFunc = func(context.Context, *goidc.AuthnSession, *goidc.Client) error {
+					if !consumed {
+						t.Fatal("CIBA session was handled before its request-object JTI was reserved")
+					}
+					return nil
+				}
 				requestObject := oidctest.Sign(t, map[string]any{
 					goidc.ClaimIssuer:           client.ID,
 					goidc.ClaimAudience:         ctx.Issuer(),
 					goidc.ClaimIssuedAt:         now,
-					goidc.ClaimExpiry:           now + 10,
+					goidc.ClaimExpiry:           expiresAt,
 					goidc.ClaimNotBefore:        now - 10,
 					goidc.ClaimTokenID:          "random_id",
 					"client_id":                 client.ID,

--- a/internal/authorize/jar.go
+++ b/internal/authorize/jar.go
@@ -157,13 +157,6 @@ func jarFromRequestObject(ctx oidc.Context, reqObject string, c *goidc.Client, o
 		}
 	}
 
-	if claims.ID != "" {
-		if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-			return request{}, goidc.WrapError(goidc.ErrorCodeInvalidRequestObject, "invalid request object",
-				fmt.Errorf("could not validate the request object jti: %w", err))
-		}
-	}
-
 	if claims.Subject != "" {
 		return request{}, goidc.WrapError(goidc.ErrorCodeInvalidRequestObject, "invalid request object",
 			errors.New("claim 'sub' is not allowed in the request object"))
@@ -174,6 +167,21 @@ func jarFromRequestObject(ctx oidc.Context, reqObject string, c *goidc.Client, o
 		AnyAudience: []string{ctx.Issuer()},
 	}, time.Duration(ctx.JWTLeewayTimeSecs)*time.Second); err != nil {
 		return request{}, goidc.WrapError(goidc.ErrorCodeInvalidRequestObject, "the request object contains invalid claims", err)
+	}
+
+	if claims.ID != "" {
+		var expiresAt time.Time
+		if claims.Expiry != nil {
+			expiresAt = claims.Expiry.Time().Add(time.Duration(ctx.JWTLeewayTimeSecs) * time.Second)
+		}
+		if err := ctx.ReserveJTI(goidc.JTIUse{
+			ID:        claims.ID,
+			Issuer:    claims.Issuer,
+			Purpose:   goidc.JTIUsePurposeRequestObject,
+			ExpiresAt: expiresAt,
+		}, goidc.ErrorCodeInvalidRequestObject, "invalid request object"); err != nil {
+			return request{}, err
+		}
 	}
 
 	return jarReq, nil

--- a/internal/authorize/jar_test.go
+++ b/internal/authorize/jar_test.go
@@ -214,6 +214,51 @@ func TestJARFromRequestObject(t *testing.T) {
 	}
 }
 
+func TestJARFromRequestObjectConsumesTypedJTIWithoutExpiry(t *testing.T) {
+	privateJWK := oidctest.PrivateRS256JWK(t, "client_key_id", goidc.KeyUsageSignature)
+	var got goidc.JTIUse
+	ctx := oidc.Context{
+		Configuration: &oidc.Configuration{
+			Host:       "https://server.example.com",
+			JAREnabled: true,
+			JARSigAlgs: []goidc.SignatureAlgorithm{goidc.SignatureAlgorithm(privateJWK.Algorithm)},
+			ConsumeJTIUseFunc: func(_ context.Context, use goidc.JTIUse) error {
+				got = use
+				return nil
+			},
+		},
+		Request: &http.Request{Method: http.MethodPost},
+	}
+	client := &goidc.Client{
+		ID: "test_client",
+		ClientMeta: goidc.ClientMeta{JWKS: &goidc.JSONWebKeySet{
+			Keys: []goidc.JSONWebKey{privateJWK.Public()},
+		}},
+	}
+	requestObject := oidctest.Sign(t, map[string]any{
+		goidc.ClaimIssuer:   client.ID,
+		goidc.ClaimAudience: ctx.Issuer(),
+		goidc.ClaimIssuedAt: timeutil.TimestampNow(),
+		goidc.ClaimTokenID:  "request-object-id",
+		"client_id":         client.ID,
+		"redirect_uri":      "https://example.com",
+		"response_type":     goidc.ResponseTypeCode,
+		"scope":             "scope",
+	}, privateJWK)
+
+	if _, err := jarFromRequestObject(ctx, requestObject, client, nil); err != nil {
+		t.Fatalf("jarFromRequestObject() error = %v", err)
+	}
+	want := goidc.JTIUse{
+		ID:      "request-object-id",
+		Issuer:  client.ID,
+		Purpose: goidc.JTIUsePurposeRequestObject,
+	}
+	if got != want {
+		t.Fatalf("JTI use = %#v, want %#v", got, want)
+	}
+}
+
 func TestJARFromRequestURI(t *testing.T) {
 	privateJWK := oidctest.PrivateRS256JWK(t, "client_key_id", goidc.KeyUsageSignature)
 	ctx := oidc.Context{

--- a/internal/client/authn.go
+++ b/internal/client/authn.go
@@ -149,6 +149,10 @@ func Authenticated(ctx oidc.Context, authnCtx AuthnContext) (*goidc.Client, erro
 	}
 
 	if err := Authenticate(ctx, c, authnCtx); err != nil {
+		var oidcErr goidc.Error
+		if errors.As(err, &oidcErr) && oidcErr.Code == goidc.ErrorCodeInternalError {
+			return nil, err
+		}
 		return nil, goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
 	}
 
@@ -258,11 +262,33 @@ func authenticatePrivateKeyJWT(ctx oidc.Context, c *goidc.Client, authnCtx Authn
 	}
 
 	claims := jwt.Claims{}
-	if err := parsedAssertion.Claims(jwk.Key, &claims); err != nil {
+	var rawClaims json.RawMessage
+	if err := parsedAssertion.Claims(jwk.Key, &claims, &rawClaims); err != nil {
 		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
 	}
 
-	return areClaimsValid(ctx, claims, c, authnCtx)
+	if err := areClaimsValid(ctx, claims, c, authnCtx); err != nil {
+		return err
+	}
+
+	header := parsedAssertion.Headers[0]
+	typ, _ := header.ExtraHeaders[jose.HeaderType].(string)
+	if err := ctx.ApplyPrivateKeyJWTAssertionPolicy(goidc.VerifiedClientAssertion{
+		Header: goidc.VerifiedClientAssertionHeader{
+			Algorithm: goidc.SignatureAlgorithm(header.Algorithm),
+			KeyID:     header.KeyID,
+			Type:      typ,
+		},
+		Claims: rawClaims,
+	}); err != nil {
+		var oidcErr goidc.Error
+		if errors.As(err, &oidcErr) && oidcErr.Code == goidc.ErrorCodeInternalError {
+			return err
+		}
+		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
+	}
+
+	return consumeClientAssertionJTI(ctx, claims)
 }
 
 func JWKMatchingHeader(ctx oidc.Context, c *goidc.Client, header jose.Header) (goidc.JSONWebKey, error) {
@@ -306,7 +332,7 @@ func authenticateSecretJWT(ctx oidc.Context, c *goidc.Client, authnCtx AuthnCont
 		return err
 	}
 
-	return nil
+	return consumeClientAssertionJTI(ctx, claims)
 }
 
 func authnSigAlgs(c *goidc.Client, authnCtx AuthnContext, algs []goidc.SignatureAlgorithm) []goidc.SignatureAlgorithm {
@@ -357,10 +383,6 @@ func areClaimsValid(ctx oidc.Context, claims jwt.Claims, client *goidc.Client, _
 			errors.New("the audience claim is invalid"))
 	}
 
-	if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
-	}
-
 	secsToExpiry := int(claims.Expiry.Time().Sub(timeutil.Now()).Seconds())
 	if secsToExpiry > ctx.JWTLifetimeSecs {
 		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client",
@@ -384,6 +406,15 @@ func areClaimsValid(ctx oidc.Context, claims jwt.Claims, client *goidc.Client, _
 		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
 	}
 	return nil
+}
+
+func consumeClientAssertionJTI(ctx oidc.Context, claims jwt.Claims) error {
+	return ctx.ReserveJTI(goidc.JTIUse{
+		ID:        claims.ID,
+		Issuer:    claims.Issuer,
+		Purpose:   goidc.JTIUsePurposeClientAssertion,
+		ExpiresAt: claims.Expiry.Time().Add(time.Duration(ctx.JWTLeewayTimeSecs) * time.Second),
+	}, goidc.ErrorCodeInvalidClient, "invalid client")
 }
 
 func authenticateSelfSignedTLSCert(ctx oidc.Context, c *goidc.Client) error {
@@ -703,10 +734,6 @@ func authenticateAttestationJWT(ctx oidc.Context, c *goidc.Client, authnCtx Auth
 			errors.New("the jti claim is required in the attestation PoP"))
 	}
 
-	if err := ctx.ConsumeJTI(popClaims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
-	}
-
 	if err := popClaims.ValidateWithLeeway(jwt.Expected{
 		Issuer:      c.ID,
 		AnyAudience: []string{ctx.Issuer()},
@@ -714,7 +741,12 @@ func authenticateAttestationJWT(ctx oidc.Context, c *goidc.Client, authnCtx Auth
 		return goidc.WrapError(goidc.ErrorCodeInvalidClient, "invalid client", err)
 	}
 
-	return nil
+	return ctx.ReserveJTI(goidc.JTIUse{
+		ID:        popClaims.ID,
+		Issuer:    popClaims.Issuer,
+		Purpose:   goidc.JTIUsePurposeClientAttestationPoP,
+		ExpiresAt: popClaims.Expiry.Time().Add(time.Duration(ctx.JWTLeewayTimeSecs) * time.Second),
+	}, goidc.ErrorCodeInvalidClient, "invalid client")
 }
 
 func comparePublicKeys(k1 any, k2 any) bool {

--- a/internal/client/authn_policy_test.go
+++ b/internal/client/authn_policy_test.go
@@ -1,0 +1,266 @@
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/luikyv/go-oidc/internal/client"
+	"github.com/luikyv/go-oidc/internal/oidctest"
+	"github.com/luikyv/go-oidc/internal/timeutil"
+	"github.com/luikyv/go-oidc/pkg/goidc"
+)
+
+func TestPrivateKeyJWTAssertionPolicyRunsBeforeJTIConsumption(t *testing.T) {
+	ctx, c, jwk := setUpPrivateKeyJWTAuthn(t)
+	ctx.JWTLeewayTimeSecs = 7
+	now := timeutil.TimestampNow()
+	expiresAt := now + ctx.JWTLifetimeSecs - 10
+	claims := map[string]any{
+		goidc.ClaimIssuer:   c.ID,
+		goidc.ClaimSubject:  c.ID,
+		goidc.ClaimAudience: ctx.Issuer(),
+		goidc.ClaimIssuedAt: now,
+		goidc.ClaimExpiry:   expiresAt,
+		goidc.ClaimTokenID:  "assertion-id",
+		"custom":            "value",
+	}
+	ctx.Request.PostForm = map[string][]string{
+		"client_assertion": {
+			oidctest.SignWithOptions(t, claims, jwk, (&jose.SignerOptions{}).WithType("JWT")),
+		},
+		"client_assertion_type": {string(goidc.AssertionTypeJWTBearer)},
+	}
+
+	var calls []string
+	ctx.PrivateKeyJWTAssertionPolicyFunc = func(_ context.Context, assertion goidc.VerifiedClientAssertion) error {
+		calls = append(calls, "policy")
+		if assertion.Header.Algorithm != goidc.SigAlgRS256 {
+			t.Errorf("policy header algorithm = %q, want %q", assertion.Header.Algorithm, goidc.SigAlgRS256)
+		}
+		if assertion.Header.KeyID != jwk.KeyID {
+			t.Errorf("policy header kid = %q, want %q", assertion.Header.KeyID, jwk.KeyID)
+		}
+		if assertion.Header.Type != "JWT" {
+			t.Errorf("policy header typ = %q, want JWT", assertion.Header.Type)
+		}
+		var gotClaims map[string]json.RawMessage
+		if err := json.Unmarshal(assertion.Claims, &gotClaims); err != nil {
+			t.Fatalf("unmarshal verified claims: %v", err)
+		}
+		if string(gotClaims["custom"]) != `"value"` {
+			t.Errorf("policy custom claim = %s, want %q", gotClaims["custom"], "value")
+		}
+		return nil
+	}
+	ctx.ConsumeJTIUseFunc = func(_ context.Context, use goidc.JTIUse) error {
+		calls = append(calls, "consume")
+		if use.ID != "assertion-id" {
+			t.Errorf("JTI ID = %q, want assertion-id", use.ID)
+		}
+		if use.Issuer != c.ID {
+			t.Errorf("JTI issuer = %q, want %q", use.Issuer, c.ID)
+		}
+		if use.Purpose != goidc.JTIUsePurposeClientAssertion {
+			t.Errorf("JTI purpose = %q, want %q", use.Purpose, goidc.JTIUsePurposeClientAssertion)
+		}
+		wantExpiry := time.Unix(int64(expiresAt+ctx.JWTLeewayTimeSecs), 0).UTC()
+		if !use.ExpiresAt.Equal(wantExpiry) {
+			t.Errorf("JTI expiry = %v, want %v", use.ExpiresAt, wantExpiry)
+		}
+		return nil
+	}
+
+	if _, err := client.Authenticated(ctx, client.AuthnContextToken); err != nil {
+		t.Fatalf("Authenticated() error = %v", err)
+	}
+	if want := []string{"policy", "consume"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("call order = %v, want %v", calls, want)
+	}
+}
+
+func TestPrivateKeyJWTAssertionPolicyRejectsBeforeJTIConsumption(t *testing.T) {
+	ctx, c, jwk := setUpPrivateKeyJWTAuthn(t)
+	now := timeutil.TimestampNow()
+	ctx.Request.PostForm = map[string][]string{
+		"client_assertion": {oidctest.Sign(t, map[string]any{
+			goidc.ClaimIssuer:   c.ID,
+			goidc.ClaimSubject:  c.ID,
+			goidc.ClaimAudience: ctx.Issuer(),
+			goidc.ClaimIssuedAt: now,
+			goidc.ClaimExpiry:   now + ctx.JWTLifetimeSecs - 10,
+			goidc.ClaimTokenID:  "assertion-id",
+		}, jwk)},
+		"client_assertion_type": {string(goidc.AssertionTypeJWTBearer)},
+	}
+	ctx.PrivateKeyJWTAssertionPolicyFunc = func(context.Context, goidc.VerifiedClientAssertion) error {
+		return errors.New("assertion violates deployment policy")
+	}
+	ctx.ConsumeJTIUseFunc = func(context.Context, goidc.JTIUse) error {
+		t.Fatal("JTI consumer called after assertion policy rejection")
+		return nil
+	}
+
+	_, err := client.Authenticated(ctx, client.AuthnContextToken)
+	assertErrorCode(t, err, goidc.ErrorCodeInvalidClient)
+}
+
+func TestPrivateKeyJWTAssertionPolicyPreservesOperationalFailure(t *testing.T) {
+	ctx, c, jwk := setUpPrivateKeyJWTAuthn(t)
+	now := timeutil.TimestampNow()
+	ctx.Request.PostForm = map[string][]string{
+		"client_assertion": {oidctest.Sign(t, map[string]any{
+			goidc.ClaimIssuer:   c.ID,
+			goidc.ClaimSubject:  c.ID,
+			goidc.ClaimAudience: ctx.Issuer(),
+			goidc.ClaimIssuedAt: now,
+			goidc.ClaimExpiry:   now + ctx.JWTLifetimeSecs - 10,
+			goidc.ClaimTokenID:  "assertion-id",
+		}, jwk)},
+		"client_assertion_type": {string(goidc.AssertionTypeJWTBearer)},
+	}
+	ctx.PrivateKeyJWTAssertionPolicyFunc = func(context.Context, goidc.VerifiedClientAssertion) error {
+		return goidc.WrapError(goidc.ErrorCodeInternalError, "internal server error", errors.New("policy store unavailable"))
+	}
+
+	_, err := client.Authenticated(ctx, client.AuthnContextToken)
+	assertErrorCode(t, err, goidc.ErrorCodeInternalError)
+}
+
+func TestTypedJTIConsumerDistinguishesReplayFromOperationalFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		consume  error
+		wantCode goidc.ErrorCode
+	}{
+		{name: "replay", consume: goidc.ErrJTIReplay, wantCode: goidc.ErrorCodeInvalidClient},
+		{name: "operational failure", consume: errors.New("store unavailable"), wantCode: goidc.ErrorCodeInternalError},
+		{name: "not found is operational", consume: goidc.ErrNotFound, wantCode: goidc.ErrorCodeInternalError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, c, jwk := setUpPrivateKeyJWTAuthn(t)
+			now := timeutil.TimestampNow()
+			ctx.Request.PostForm = map[string][]string{
+				"client_assertion": {oidctest.Sign(t, map[string]any{
+					goidc.ClaimIssuer:   c.ID,
+					goidc.ClaimSubject:  c.ID,
+					goidc.ClaimAudience: ctx.Issuer(),
+					goidc.ClaimIssuedAt: now,
+					goidc.ClaimExpiry:   now + ctx.JWTLifetimeSecs - 10,
+					goidc.ClaimTokenID:  "assertion-id",
+				}, jwk)},
+				"client_assertion_type": {string(goidc.AssertionTypeJWTBearer)},
+			}
+			ctx.ConsumeJTIUseFunc = func(context.Context, goidc.JTIUse) error { return tc.consume }
+
+			_, err := client.Authenticated(ctx, client.AuthnContextToken)
+			assertErrorCode(t, err, tc.wantCode)
+		})
+	}
+}
+
+func TestInvalidPrivateKeyJWTClaimsAreNotConsumed(t *testing.T) {
+	ctx, c, jwk := setUpPrivateKeyJWTAuthn(t)
+	now := timeutil.TimestampNow()
+	ctx.Request.PostForm = map[string][]string{
+		"client_assertion": {oidctest.Sign(t, map[string]any{
+			goidc.ClaimIssuer:   c.ID,
+			goidc.ClaimSubject:  c.ID,
+			goidc.ClaimAudience: "https://wrong.example",
+			goidc.ClaimIssuedAt: now,
+			goidc.ClaimExpiry:   now + ctx.JWTLifetimeSecs - 10,
+			goidc.ClaimTokenID:  "assertion-id",
+		}, jwk)},
+		"client_assertion_type": {string(goidc.AssertionTypeJWTBearer)},
+	}
+	ctx.ConsumeJTIUseFunc = func(context.Context, goidc.JTIUse) error {
+		t.Fatal("JTI consumer called before claims validation")
+		return nil
+	}
+
+	_, err := client.Authenticated(ctx, client.AuthnContextToken)
+	assertErrorCode(t, err, goidc.ErrorCodeInvalidClient)
+}
+
+func TestSecretJWTConsumesTypedJTI(t *testing.T) {
+	ctx, c, secret := setUpClientSecretJWTAuthn(t)
+	ctx.Request.PostForm = secretJWTPostForm(t, ctx, c.ID, secret, "secret-assertion-id")
+	var got goidc.JTIUse
+	ctx.ConsumeJTIUseFunc = func(_ context.Context, use goidc.JTIUse) error {
+		got = use
+		return nil
+	}
+
+	if _, err := client.Authenticated(ctx, client.AuthnContextToken); err != nil {
+		t.Fatalf("Authenticated() error = %v", err)
+	}
+	if got.ID != "secret-assertion-id" {
+		t.Errorf("JTI ID = %q, want secret-assertion-id", got.ID)
+	}
+	if got.Issuer != c.ID {
+		t.Errorf("JTI issuer = %q, want %q", got.Issuer, c.ID)
+	}
+	if got.Purpose != goidc.JTIUsePurposeClientAssertion {
+		t.Errorf("JTI purpose = %q, want %q", got.Purpose, goidc.JTIUsePurposeClientAssertion)
+	}
+	if !got.ExpiresAt.After(time.Now()) {
+		t.Errorf("JTI expiry = %v, want a future time", got.ExpiresAt)
+	}
+}
+
+func TestAttestationPoPConsumesTypedJTI(t *testing.T) {
+	ctx, c, issuerKey, clientKey := setUpAttestationAuthn(t)
+	cnfJWK := jose.JSONWebKey{Key: clientKey.Public(), Algorithm: string(goidc.SigAlgES256)}
+	clientJWK := goidc.JSONWebKey{Key: clientKey, Algorithm: string(goidc.SigAlgES256)}
+	attestation := oidctest.SignWithOptions(t, map[string]any{
+		goidc.ClaimIssuer:  "https://attester.example.com",
+		goidc.ClaimSubject: c.ID,
+		goidc.ClaimExpiry:  timeutil.TimestampNow() + 300,
+		"cnf":              map[string]any{"jwk": cnfJWK},
+	}, issuerKey, (&jose.SignerOptions{}).WithType("oauth-client-attestation+jwt"))
+	ctx.Request.Header.Set("Oauth-Client-Attestation", attestation)
+
+	expiresAt := timeutil.TimestampNow() + 60
+	pop := oidctest.SignWithOptions(t, map[string]any{
+		goidc.ClaimIssuer:   c.ID,
+		goidc.ClaimAudience: ctx.Issuer(),
+		goidc.ClaimExpiry:   expiresAt,
+		goidc.ClaimIssuedAt: timeutil.TimestampNow(),
+		goidc.ClaimTokenID:  "attestation-pop-id",
+	}, clientJWK, (&jose.SignerOptions{}).WithType("oauth-client-attestation-pop+jwt"))
+	ctx.Request.Header.Set("Oauth-Client-Attestation-Pop", pop)
+
+	var got goidc.JTIUse
+	ctx.ConsumeJTIUseFunc = func(_ context.Context, use goidc.JTIUse) error {
+		got = use
+		return nil
+	}
+	if _, err := client.Authenticated(ctx, client.AuthnContextToken); err != nil {
+		t.Fatalf("Authenticated() error = %v", err)
+	}
+	wantExpiry := time.Unix(int64(expiresAt+ctx.JWTLeewayTimeSecs), 0).UTC()
+	if got.ID != "attestation-pop-id" || got.Issuer != c.ID || got.Purpose != goidc.JTIUsePurposeClientAttestationPoP {
+		t.Fatalf("JTI use = %#v, want attestation PoP reservation", got)
+	}
+	if !got.ExpiresAt.Equal(wantExpiry) {
+		t.Fatalf("JTI expiry = %v, want %v", got.ExpiresAt, wantExpiry)
+	}
+}
+
+func assertErrorCode(t *testing.T, err error, want goidc.ErrorCode) {
+	t.Helper()
+	var oidcErr goidc.Error
+	if !errors.As(err, &oidcErr) {
+		t.Fatalf("error = %v, want goidc.Error", err)
+	}
+	if oidcErr.Code != want {
+		t.Fatalf("error code = %q, want %q (error: %v)", oidcErr.Code, want, err)
+	}
+	if oidcErr.StatusCode() != want.StatusCode() {
+		t.Fatalf("HTTP status = %d, want %d", oidcErr.StatusCode(), want.StatusCode())
+	}
+}

--- a/internal/dpop/util.go
+++ b/internal/dpop/util.go
@@ -84,8 +84,13 @@ func ValidateJWT(ctx oidc.Context, dpopJWT string, opts ValidationOptions) error
 	}
 
 	// Validate that the "iat" claim is present and it is not too far in the past.
-	if claims.IssuedAt == nil ||
-		int(timeutil.Now().Sub(claims.IssuedAt.Time()).Seconds()) > ctx.JWTLifetimeSecs {
+	if claims.IssuedAt == nil {
+		return goidc.WrapError(goidc.ErrorCodeUnauthorizedClient, "unauthorized client",
+			errors.New("the DPoP proof issuance time is invalid"))
+	}
+	acceptedUntil := claims.IssuedAt.Time().Add(time.Duration(ctx.JWTLifetimeSecs) * time.Second)
+	now := timeutil.Now()
+	if !now.Before(acceptedUntil) {
 		return goidc.WrapError(goidc.ErrorCodeUnauthorizedClient, "unauthorized client",
 			errors.New("the DPoP proof issuance time is invalid"))
 	}
@@ -93,10 +98,6 @@ func ValidateJWT(ctx oidc.Context, dpopJWT string, opts ValidationOptions) error
 	if claims.ID == "" {
 		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof",
 			errors.New("the jti claim is required"))
-	}
-
-	if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
 	}
 
 	if dpopClaims.HTTPMethod != ctx.RequestMethod() {
@@ -126,6 +127,20 @@ func ValidateJWT(ctx oidc.Context, dpopJWT string, opts ValidationOptions) error
 
 	if err = claims.ValidateWithLeeway(jwt.Expected{}, time.Duration(ctx.JWTLeewayTimeSecs)*time.Second); err != nil {
 		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
+	}
+
+	thumbprint, err := jwk.Thumbprint(crypto.SHA256)
+	if err != nil {
+		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
+	}
+	err = ctx.ReserveJTI(goidc.JTIUse{
+		ID:        claims.ID,
+		Issuer:    base64.RawURLEncoding.EncodeToString(thumbprint),
+		Purpose:   goidc.JTIUsePurposeDPoPProof,
+		ExpiresAt: acceptedUntil,
+	}, goidc.ErrorCodeInvalidRequest, "invalid DPoP proof")
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/dpop/util_test.go
+++ b/internal/dpop/util_test.go
@@ -2,13 +2,16 @@ package dpop_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/luikyv/go-oidc/internal/dpop"
 	"github.com/luikyv/go-oidc/internal/oidc"
+	"github.com/luikyv/go-oidc/internal/oidctest"
 	"github.com/luikyv/go-oidc/pkg/goidc"
 )
 
@@ -71,6 +74,131 @@ func TestValidateJWT(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+func TestValidateJWTConsumesTypedJTIOnlyAfterProofValidation(t *testing.T) {
+	const lifetime = 60
+	proof, thumbprint := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    "https://server.example.com/token",
+	})
+	request := httptest.NewRequest(http.MethodPost, "/token", nil)
+	ctx := oidc.Context{
+		Configuration: &oidc.Configuration{
+			Host:            "https://server.example.com",
+			DPoPEnabled:     true,
+			DPoPSigAlgs:     []goidc.SignatureAlgorithm{goidc.SigAlgES256},
+			JWTLifetimeSecs: lifetime,
+		},
+		Request: request,
+	}
+
+	before := time.Now().UTC().Add(lifetime * time.Second)
+	var got goidc.JTIUse
+	ctx.ConsumeJTIUseFunc = func(_ context.Context, use goidc.JTIUse) error {
+		got = use
+		return nil
+	}
+	if err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{}); err != nil {
+		t.Fatalf("ValidateJWT() error = %v", err)
+	}
+	after := time.Now().UTC().Add(lifetime * time.Second)
+
+	if got.ID == "" {
+		t.Fatal("typed JTI consumer was not called")
+	}
+	if got.Issuer != thumbprint {
+		t.Errorf("JTI issuer = %q, want DPoP key thumbprint %q", got.Issuer, thumbprint)
+	}
+	if got.Purpose != goidc.JTIUsePurposeDPoPProof {
+		t.Errorf("JTI purpose = %q, want %q", got.Purpose, goidc.JTIUsePurposeDPoPProof)
+	}
+	if got.ExpiresAt.Before(before.Add(-time.Second)) || got.ExpiresAt.After(after) {
+		t.Errorf("JTI expiry = %v, want between %v and %v", got.ExpiresAt, before, after)
+	}
+
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/token", nil)
+	ctx.ConsumeJTIUseFunc = func(context.Context, goidc.JTIUse) error {
+		t.Fatal("JTI consumer called before HTTP method validation")
+		return nil
+	}
+	if err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{}); err == nil {
+		t.Fatal("ValidateJWT() error = nil for invalid HTTP method")
+	}
+}
+
+func TestValidateJWTTypedJTIConsumerErrors(t *testing.T) {
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    "https://server.example.com/token",
+	})
+	for _, tc := range []struct {
+		name     string
+		consume  error
+		wantCode goidc.ErrorCode
+	}{
+		{name: "replay", consume: goidc.ErrJTIReplay, wantCode: goidc.ErrorCodeInvalidRequest},
+		{name: "operational failure", consume: errors.New("store unavailable"), wantCode: goidc.ErrorCodeInternalError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := oidc.Context{
+				Configuration: &oidc.Configuration{
+					Host:            "https://server.example.com",
+					DPoPEnabled:     true,
+					DPoPSigAlgs:     []goidc.SignatureAlgorithm{goidc.SigAlgES256},
+					JWTLifetimeSecs: 60,
+					ConsumeJTIUseFunc: func(context.Context, goidc.JTIUse) error {
+						return tc.consume
+					},
+				},
+				Request: httptest.NewRequest(http.MethodPost, "/token", nil),
+			}
+
+			err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{})
+			var oidcErr goidc.Error
+			if !errors.As(err, &oidcErr) {
+				t.Fatalf("error = %v, want goidc.Error", err)
+			}
+			if oidcErr.Code != tc.wantCode {
+				t.Fatalf("error code = %q, want %q (error: %v)", oidcErr.Code, tc.wantCode, err)
+			}
+			if oidcErr.StatusCode() != tc.wantCode.StatusCode() {
+				t.Fatalf("HTTP status = %d, want %d", oidcErr.StatusCode(), tc.wantCode.StatusCode())
+			}
+		})
+	}
+}
+
+func TestValidateJWTRejectsProofAtReservationExpiryBoundary(t *testing.T) {
+	const lifetime = 60
+	issuedAt := time.Now().UTC().Truncate(time.Second).Add(-lifetime * time.Second)
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method:   http.MethodPost,
+		URI:      "https://server.example.com/token",
+		IssuedAt: issuedAt,
+	})
+	ctx := oidc.Context{
+		Configuration: &oidc.Configuration{
+			Host:            "https://server.example.com",
+			DPoPEnabled:     true,
+			DPoPSigAlgs:     []goidc.SignatureAlgorithm{goidc.SigAlgES256},
+			JWTLifetimeSecs: lifetime,
+			ConsumeJTIUseFunc: func(context.Context, goidc.JTIUse) error {
+				t.Fatal("expired DPoP proof was reserved")
+				return nil
+			},
+		},
+		Request: httptest.NewRequest(http.MethodPost, "/token", nil),
+	}
+
+	err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{})
+	var oidcErr goidc.Error
+	if !errors.As(err, &oidcErr) {
+		t.Fatalf("error = %v, want goidc.Error", err)
+	}
+	if oidcErr.Code != goidc.ErrorCodeUnauthorizedClient {
+		t.Fatalf("error code = %q, want %q", oidcErr.Code, goidc.ErrorCodeUnauthorizedClient)
 	}
 }
 

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -207,8 +207,11 @@ type Configuration struct {
 	ResourceIndicatorsRequired bool
 	ResourceIndicators         []goidc.ResourceIndicator
 
-	HTTPClientFunc goidc.HTTPClientFunc
-	ConsumeJTIFunc goidc.ConsumeJTIFunc
+	HTTPClientFunc    goidc.HTTPClientFunc
+	ConsumeJTIFunc    goidc.ConsumeJTIFunc
+	ConsumeJTIUseFunc goidc.ConsumeJTIUseFunc
+
+	PrivateKeyJWTAssertionPolicyFunc goidc.PrivateKeyJWTAssertionPolicyFunc
 
 	JWTBearerClientAuthnRequired bool
 	JWTBearerHandleAssertionFunc goidc.JWTBearerHandleAssertionFunc

--- a/internal/oidc/context.go
+++ b/internal/oidc/context.go
@@ -121,6 +121,45 @@ func (ctx Context) ConsumeJTI(jti string) error {
 	return ctx.ConsumeJTIFunc(ctx, jti)
 }
 
+func (ctx Context) ConsumeJTIUse(use goidc.JTIUse) error {
+	if ctx.ConsumeJTIUseFunc != nil {
+		return ctx.ConsumeJTIUseFunc(ctx, use)
+	}
+	return ctx.ConsumeJTIFunc(ctx, use.ID)
+}
+
+func (ctx Context) UsesTypedJTIConsumer() bool {
+	return ctx.ConsumeJTIUseFunc != nil
+}
+
+// ReserveJTI atomically reserves a validated JTI and maps typed-consumer replay
+// and operational failures to their appropriate protocol errors. Legacy
+// consumers retain their historical behavior, where every callback error is a
+// protocol rejection.
+func (ctx Context) ReserveJTI(use goidc.JTIUse, replayCode goidc.ErrorCode, replayDescription string) error {
+	err := ctx.ConsumeJTIUse(use)
+	if err == nil {
+		return nil
+	}
+	if ctx.UsesTypedJTIConsumer() {
+		if errors.Is(err, goidc.ErrJTIReplay) {
+			return goidc.WrapError(replayCode, replayDescription, err)
+		}
+		return goidc.WrapError(goidc.ErrorCodeInternalError, "internal server error", err)
+	}
+	if errors.Is(err, goidc.ErrNotFound) {
+		return nil
+	}
+	return goidc.WrapError(replayCode, replayDescription, err)
+}
+
+func (ctx Context) ApplyPrivateKeyJWTAssertionPolicy(assertion goidc.VerifiedClientAssertion) error {
+	if ctx.PrivateKeyJWTAssertionPolicyFunc == nil {
+		return nil
+	}
+	return ctx.PrivateKeyJWTAssertionPolicyFunc(ctx, assertion)
+}
+
 func (ctx Context) RenderError(err error) error {
 	if ctx.RenderErrorFunc == nil {
 		// No need to notify error here, since this error will end up being

--- a/internal/oidc/context_test.go
+++ b/internal/oidc/context_test.go
@@ -479,6 +479,25 @@ func TestTokenAndPolicyHooks(t *testing.T) {
 			},
 		},
 		{
+			name: "check typed jti",
+			run: func(t *testing.T, ctx oidc.Context) {
+				want := goidc.JTIUse{
+					ID:      "jti",
+					Issuer:  "issuer",
+					Purpose: goidc.JTIUsePurposeClientAssertion,
+				}
+				ctx.ConsumeJTIUseFunc = func(_ context.Context, got goidc.JTIUse) error {
+					if got != want {
+						t.Fatalf("ConsumeJTIUse() use = %#v, want %#v", got, want)
+					}
+					return nil
+				}
+				if err := ctx.ConsumeJTIUse(want); err != nil {
+					t.Fatalf("ConsumeJTIUse() error = %v", err)
+				}
+			},
+		},
+		{
 			name: "render error",
 			run: func(t *testing.T, ctx oidc.Context) {
 				err := errors.New("error")

--- a/internal/oidctest/util.go
+++ b/internal/oidctest/util.go
@@ -404,8 +404,9 @@ func Sign(tb testing.TB, claims map[string]any, jwk goidc.JSONWebKey) string {
 
 // DPoPProofOptions configures DPoP proof generation.
 type DPoPProofOptions struct {
-	Method string
-	URI    string
+	Method   string
+	URI      string
+	IssuedAt time.Time
 	// Key is the private key used to sign the proof. If nil, a fresh ES256 key
 	// is generated.
 	Key crypto.PrivateKey
@@ -453,11 +454,15 @@ func DPoPProof(tb testing.TB, opts DPoPProofOptions) (dpopJWT string, thumbprint
 		tb.Fatalf("could not create DPoP signer: %v", err)
 	}
 
+	issuedAt := opts.IssuedAt
+	if issuedAt.IsZero() {
+		issuedAt = time.Now()
+	}
 	claims := map[string]any{
 		"jti": uuid.NewString(),
 		"htm": opts.Method,
 		"htu": opts.URI,
-		"iat": time.Now().Unix(),
+		"iat": issuedAt.Unix(),
 	}
 	payload, err := json.Marshal(claims)
 	if err != nil {

--- a/pkg/goidc/error.go
+++ b/pkg/goidc/error.go
@@ -14,6 +14,11 @@ import (
 // operational failures and to produce the correct protocol behavior.
 var ErrNotFound = errors.New("not found")
 
+// ErrJTIReplay signals that a JWT ID has already been consumed. JTI consumer
+// implementations should return this error, or wrap it, for a replay. Other
+// errors are treated as operational failures by the provider.
+var ErrJTIReplay = errors.New("jti replay")
+
 type ErrorCode string
 
 const (

--- a/pkg/goidc/model.go
+++ b/pkg/goidc/model.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 )
 
 type Configuration struct {
@@ -535,6 +536,55 @@ func NewDynamicScope(scope string, matchingFunc MatchScopeFunc) Scope {
 
 // ConsumeJTIFunc defines a function to verify when a JTI is safe to use.
 type ConsumeJTIFunc func(context.Context, string) error
+
+// JTIUsePurpose identifies the protocol artifact whose JWT ID is consumed.
+type JTIUsePurpose string
+
+const (
+	JTIUsePurposeClientAssertion      JTIUsePurpose = "client_assertion"
+	JTIUsePurposeDPoPProof            JTIUsePurpose = "dpop_proof"
+	JTIUsePurposeRequestObject        JTIUsePurpose = "request_object"
+	JTIUsePurposeClientAttestationPoP JTIUsePurpose = "client_attestation_pop"
+)
+
+// JTIUse describes a validated JWT ID reservation. ExpiresAt is the time after
+// which the artifact can no longer be accepted by the provider. It is zero when
+// the artifact does not declare an upper acceptance bound.
+type JTIUse struct {
+	ID        string
+	Issuer    string
+	Purpose   JTIUsePurpose
+	ExpiresAt time.Time
+}
+
+// ConsumeJTIUseFunc atomically reserves a validated JWT ID. Implementations
+// must be safe for concurrent calls. They should return ErrJTIReplay when the
+// use was already reserved and any other error, including ErrNotFound, for an
+// operational failure.
+type ConsumeJTIUseFunc func(context.Context, JTIUse) error
+
+// VerifiedClientAssertionHeader is the bounded subset of a JOSE header exposed
+// to a private_key_jwt assertion policy after signature verification.
+type VerifiedClientAssertionHeader struct {
+	Algorithm SignatureAlgorithm
+	KeyID     string
+	Type      string
+}
+
+// VerifiedClientAssertion contains the protected header fields and claims of a
+// client assertion whose signature and standard claims have been verified.
+// Custom headers and claims remain client-controlled: validate them before use,
+// and do not log the raw claims because they may contain sensitive values.
+type VerifiedClientAssertion struct {
+	Header VerifiedClientAssertionHeader
+	Claims json.RawMessage
+}
+
+// PrivateKeyJWTAssertionPolicyFunc applies deployment-specific policy to a
+// signature-verified private_key_jwt client assertion. Policy rejections are
+// exposed as invalid_client. Return an Error with ErrorCodeInternalError for an
+// operational failure that must fail closed as an internal server error.
+type PrivateKeyJWTAssertionPolicyFunc func(context.Context, VerifiedClientAssertion) error
 
 // HTTPClientFunc defines a function that generates an HTTP client for performing
 // requests.

--- a/pkg/provider/option.go
+++ b/pkg/provider/option.go
@@ -168,13 +168,23 @@ func WithJWTLeewayTime(secs int) Option {
 	}
 }
 
-// WithJTIConsumer registers a function to validate JWT IDs (JTI) during JWT
-// processing.
+// WithJTIConsumer registers the legacy function to validate JWT IDs (JTI)
+// during JWT processing. It cannot be combined with WithJTIUseConsumer.
 // This function is used to prevent replay attacks by ensuring that each JTI is
 // unique and not reused.
 func WithJTIConsumer(f goidc.ConsumeJTIFunc) Option {
 	return func(p *Provider) error {
 		p.config.ConsumeJTIFunc = f
+		return nil
+	}
+}
+
+// WithJTIUseConsumer registers a typed, atomic JWT ID consumer. Unlike the
+// legacy JTI consumer, operational errors are distinguished from ErrJTIReplay.
+// It cannot be combined with WithJTIConsumer.
+func WithJTIUseConsumer(f goidc.ConsumeJTIUseFunc) Option {
+	return func(p *Provider) error {
+		p.config.ConsumeJTIUseFunc = f
 		return nil
 	}
 }
@@ -389,6 +399,16 @@ func WithPrivateKeyJWTAuthn(algs ...goidc.SignatureAlgorithm) Option {
 		}
 		p.config.AuthnMethods = append(p.config.AuthnMethods, goidc.AuthnMethodPrivateKeyJWT)
 		p.config.AuthnMethodPrivateKeyJWTSigAlgs = algs
+		return nil
+	}
+}
+
+// WithPrivateKeyJWTAssertionPolicy registers deployment-specific validation
+// that runs after a private_key_jwt assertion signature is verified and before
+// its JTI is consumed.
+func WithPrivateKeyJWTAssertionPolicy(f goidc.PrivateKeyJWTAssertionPolicyFunc) Option {
+	return func(p *Provider) error {
+		p.config.PrivateKeyJWTAssertionPolicyFunc = f
 		return nil
 	}
 }

--- a/pkg/provider/option_test.go
+++ b/pkg/provider/option_test.go
@@ -1909,6 +1909,30 @@ func TestWithJTIConsumer(t *testing.T) {
 	}
 }
 
+func TestWithJTIUseConsumer(t *testing.T) {
+	p := &Provider{config: oidc.Configuration{}}
+	consumer := func(context.Context, goidc.JTIUse) error { return nil }
+
+	if err := WithJTIUseConsumer(consumer)(p); err != nil {
+		t.Fatalf("WithJTIUseConsumer() error = %v", err)
+	}
+	if p.config.ConsumeJTIUseFunc == nil {
+		t.Fatal("ConsumeJTIUseFunc cannot be nil")
+	}
+}
+
+func TestWithPrivateKeyJWTAssertionPolicy(t *testing.T) {
+	p := &Provider{config: oidc.Configuration{}}
+	policy := func(context.Context, goidc.VerifiedClientAssertion) error { return nil }
+
+	if err := WithPrivateKeyJWTAssertionPolicy(policy)(p); err != nil {
+		t.Fatalf("WithPrivateKeyJWTAssertionPolicy() error = %v", err)
+	}
+	if p.config.PrivateKeyJWTAssertionPolicyFunc == nil {
+		t.Fatal("PrivateKeyJWTAssertionPolicyFunc cannot be nil")
+	}
+}
+
 func TestWithResourceIndicators(t *testing.T) {
 	// Given.
 	p := &Provider{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -130,8 +130,12 @@ func New(cfg Config, opts ...Option) (*Provider, error) {
 		return nil, errors.New("dcr secret rotation requires a secret-based token authentication method")
 	}
 
-	if op.config.ConsumeJTIFunc == nil {
-		slog.Warn("ConsumeJTIFunc is not configured; JTI replay protection is disabled. Configure provider.WithJTIConsumer for production use.")
+	if op.config.ConsumeJTIFunc != nil && op.config.ConsumeJTIUseFunc != nil {
+		return nil, errors.New("legacy and typed JTI consumers are mutually exclusive")
+	}
+
+	if op.config.ConsumeJTIFunc == nil && op.config.ConsumeJTIUseFunc == nil {
+		slog.Warn("JTI consumer is not configured; JTI replay protection is disabled. Configure provider.WithJTIUseConsumer for production use.")
 	}
 
 	inmemoryManager := storage.NewManager(defaultStorageMaxSize)
@@ -150,7 +154,9 @@ func New(cfg Config, opts ...Option) (*Provider, error) {
 	op.config.TokenOptionsFunc = nonZeroOrDefault(op.config.TokenOptionsFunc, defaultTokenOptionsFunc(op.config.IDTokenDefaultSigAlg))
 
 	op.config.VerifyClientSecretFunc = nonZeroOrDefault(op.config.VerifyClientSecretFunc, goidc.VerifyClientSecretFunc(defaultVerifyClientSecretFunc))
-	op.config.ConsumeJTIFunc = nonZeroOrDefault(op.config.ConsumeJTIFunc, goidc.ConsumeJTIFunc(defaultConsumeJTIFunc))
+	if op.config.ConsumeJTIFunc == nil && op.config.ConsumeJTIUseFunc == nil {
+		op.config.ConsumeJTIFunc = defaultConsumeJTIFunc
+	}
 	op.config.HandleErrorFunc = nonZeroOrDefault(op.config.HandleErrorFunc, goidc.HandleErrorFunc(defaultHandleErrorFunc))
 	op.config.HandleGrantFunc = nonZeroOrDefault(op.config.HandleGrantFunc, goidc.HandleGrantFunc(defaultHandleGrantFunc))
 	op.config.HandleTokenFunc = nonZeroOrDefault(op.config.HandleTokenFunc, goidc.HandleTokenFunc(defaultHandleTokenFunc))

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -260,6 +260,22 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewRejectsLegacyAndTypedJTIConsumers(t *testing.T) {
+	_, err := New(Config{
+		Issuer: "https://example.com",
+		JWKS: func(context.Context) (goidc.JSONWebKeySet, error) {
+			return goidc.JSONWebKeySet{}, nil
+		},
+		IDTokenAlgs: []goidc.SignatureAlgorithm{goidc.SigAlgRS256},
+	},
+		WithJTIConsumer(func(context.Context, string) error { return nil }),
+		WithJTIUseConsumer(func(context.Context, goidc.JTIUse) error { return nil }),
+	)
+	if err == nil {
+		t.Fatal("New() error = nil, want mutually exclusive JTI consumer error")
+	}
+}
+
 func TestNew_DefaultsVCISelfBatchSize(t *testing.T) {
 	p, err := New(Config{
 		Issuer:      "https://example.com",


### PR DESCRIPTION
## Summary

- add a typed JTI reservation contract carrying ID, issuer, protocol purpose, and the exact acceptance expiry
- distinguish atomic replay conflicts from operational storage failures with goidc.ErrJTIReplay
- reserve JTIs only after signature, claims, and request-specific validation for client assertions, DPoP proofs, JAR, CIBA request objects, and attestation PoP
- retain the legacy JTI callback while rejecting ambiguous dual configuration
- add a post-verification private_key_jwt assertion-policy hook with a bounded JOSE header view
- close the sub-second gap between DPoP validation and replay-record expiry

Typed consumer failures fail closed as internal_error unless they are explicit replay conflicts. Legacy ErrNotFound behavior remains compatible only on the legacy callback.

## Verification

- go test ./...
- go test -race ./internal/client ./internal/dpop ./internal/authorize ./internal/oidc ./pkg/provider ./pkg/goidc
- go vet ./...
- golangci-lint run
- git diff --check

The tests cover private_key_jwt, client_secret_jwt, JAR including zero-expiry reservations, CIBA request objects, DPoP, and client-attestation PoP.
