### PR TITLE
feat: support compliant machine-only FAPI profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,8 +1118,9 @@ requests, the client may ask for a subset of the originally granted resources.
 The provider rejects resources that were not granted or that are not part of
 the configured allowed list.
 
-Use `provider.ResourceIndicatorsRequired()` if every authorization
-request must include a `resource` parameter.
+Pass `provider.WithResourceIndicatorsRequired()` to
+`provider.WithResourceIndicators(...)` if every authorization request and
+client credentials token request must include a `resource` parameter.
 
 ## [OpenID Federation](https://openid.net/specs/openid-federation-1_0.html)
 

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -203,7 +203,8 @@ type Configuration struct {
 
 	ResourceIndicatorsEnabled bool
 	// ResourceIndicatorsRequired indicates that the resource parameter is
-	// required during authorization requests.
+	// required during authorization requests and client credentials token
+	// requests.
 	ResourceIndicatorsRequired bool
 	ResourceIndicators         []goidc.ResourceIndicator
 

--- a/internal/token/api.go
+++ b/internal/token/api.go
@@ -33,6 +33,10 @@ func handleCreate(ctx oidc.Context) {
 	req := newRequest(ctx.Request)
 	tokenResp, err := generateToken(ctx, req)
 	if err != nil {
+		var oidcErr goidc.Error
+		if errors.As(err, &oidcErr) && oidcErr.Code == goidc.ErrorCodeUnauthorizedClient {
+			err = oidcErr.WithStatusCode(http.StatusBadRequest)
+		}
 		ctx.WriteError(err)
 		return
 	}

--- a/internal/token/api_test.go
+++ b/internal/token/api_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -179,6 +180,66 @@ func TestTokenHandlersInvalidContentType(t *testing.T) {
 			}
 			if !strings.Contains(rec.Body.String(), string(goidc.ErrorCodeInvalidRequest)) {
 				t.Fatalf("response = %s, want invalid_request", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestTokenEndpointErrorStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		setup      func(*goidc.Client, url.Values)
+		wantCode   goidc.ErrorCode
+		wantStatus int
+	}{
+		{
+			name: "invalid client authentication uses 401",
+			setup: func(_ *goidc.Client, form url.Values) {
+				form.Set("client_secret", "invalid_secret")
+			},
+			wantCode:   goidc.ErrorCodeInvalidClient,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name: "unauthorized client uses 400",
+			setup: func(client *goidc.Client, _ url.Values) {
+				client.GrantTypes = []goidc.GrantType{goidc.GrantAuthorizationCode}
+			},
+			wantCode:   goidc.ErrorCodeUnauthorizedClient,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			client, secret := oidctest.NewClient(t)
+			ctx.StaticClients = append(ctx.StaticClients, client)
+			form := url.Values{
+				"grant_type":    {string(goidc.GrantClientCredentials)},
+				"client_id":     {client.ID},
+				"client_secret": {secret},
+				"scope":         {"scope1"},
+			}
+			test.setup(client, form)
+
+			req := httptest.NewRequest(http.MethodPost, ctx.TokenEndpoint, strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+
+			handleCreate(oidc.NewHTTPContext(rec, req, ctx.Configuration))
+
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, test.wantStatus)
+			}
+			var body struct {
+				Error goidc.ErrorCode `json:"error"`
+			}
+			if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body.Error != test.wantCode {
+				t.Fatalf("error = %s, want %s", body.Error, test.wantCode)
 			}
 		})
 	}

--- a/internal/token/client_credentials.go
+++ b/internal/token/client_credentials.go
@@ -29,6 +29,11 @@ func generateClientCredentialsToken(ctx oidc.Context, req request) (response, er
 		return response{}, err
 	}
 
+	if ctx.ResourceIndicatorsEnabled && ctx.ResourceIndicatorsRequired && req.resources == nil {
+		return response{}, goidc.WrapError(goidc.ErrorCodeInvalidTarget, "invalid target",
+			errors.New("the resource parameter is required"))
+	}
+
 	if err := validateResources(ctx, req, nil); err != nil {
 		return response{}, err
 	}

--- a/internal/token/client_credentials_test.go
+++ b/internal/token/client_credentials_test.go
@@ -117,6 +117,53 @@ func TestGenerateClientCredentialsToken(t *testing.T) {
 			},
 		},
 		{
+			name: "required resource indicator is missing",
+			setup: func() (oidc.Context, request, *goidc.Client) {
+				ctx, req, c := setup(t)
+				ctx.ResourceIndicatorsEnabled = true
+				ctx.ResourceIndicatorsRequired = true
+				ctx.ResourceIndicators = []string{"https://resource.com"}
+				return ctx, req, c
+			},
+			wantErr: goidc.ErrorCodeInvalidTarget,
+		},
+		{
+			name: "required resource indicator is empty",
+			setup: func() (oidc.Context, request, *goidc.Client) {
+				ctx, req, c := setup(t)
+				ctx.ResourceIndicatorsEnabled = true
+				ctx.ResourceIndicatorsRequired = true
+				ctx.ResourceIndicators = []string{"https://resource.com"}
+				req.resources = []string{""}
+				return ctx, req, c
+			},
+			wantErr: goidc.ErrorCodeInvalidTarget,
+		},
+		{
+			name: "multiple required resource indicators",
+			setup: func() (oidc.Context, request, *goidc.Client) {
+				ctx, req, c := setup(t)
+				ctx.ResourceIndicatorsEnabled = true
+				ctx.ResourceIndicatorsRequired = true
+				ctx.ResourceIndicators = []string{"https://resource.com", "https://other-resource.com"}
+				req.resources = []string{"https://resource.com", "https://other-resource.com"}
+				return ctx, req, c
+			},
+			validate: func(t *testing.T, ctx oidc.Context, resp response, _ *goidc.Client) {
+				want := goidc.Resources{"https://resource.com", "https://other-resource.com"}
+				grants := oidctest.Grants(t, ctx)
+				if len(grants) != 1 {
+					t.Fatalf("len(grants) = %d, want 1", len(grants))
+				}
+				if diff := cmp.Diff(grants[0].Resources, want); diff != "" {
+					t.Error(diff)
+				}
+				if diff := cmp.Diff(resp.Resources, want); diff != "" {
+					t.Error(diff)
+				}
+			},
+		},
+		{
 			name: "auth details",
 			setup: func() (oidc.Context, request, *goidc.Client) {
 				ctx, req, c := setup(t)

--- a/pkg/provider/option.go
+++ b/pkg/provider/option.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -1589,8 +1590,19 @@ type ResourceIndicatorOption Option
 // to access.
 func WithResourceIndicators(resources []goidc.ResourceIndicator, opts ...ResourceIndicatorOption) Option {
 	return func(p *Provider) error {
+		seen := make(map[string]struct{}, len(resources))
+		for _, resource := range resources {
+			parsed, err := url.Parse(resource)
+			if err != nil || !parsed.IsAbs() || parsed.Fragment != "" {
+				return fmt.Errorf("resource indicator %q must be an absolute URI without a fragment", resource)
+			}
+			if _, exists := seen[resource]; exists {
+				return fmt.Errorf("resource indicator %q is configured more than once", resource)
+			}
+			seen[resource] = struct{}{}
+		}
 		p.config.ResourceIndicatorsEnabled = true
-		p.config.ResourceIndicators = resources
+		p.config.ResourceIndicators = slices.Clone(resources)
 		for _, opt := range opts {
 			if err := opt(p); err != nil {
 				return err
@@ -1600,7 +1612,8 @@ func WithResourceIndicators(resources []goidc.ResourceIndicator, opts ...Resourc
 	}
 }
 
-// WithResourceIndicatorsRequired makes resource indicators required.
+// WithResourceIndicatorsRequired makes resource indicators required for
+// authorization requests and client credentials token requests.
 func WithResourceIndicatorsRequired() ResourceIndicatorOption {
 	return func(p *Provider) error {
 		p.config.ResourceIndicatorsRequired = true

--- a/pkg/provider/option_test.go
+++ b/pkg/provider/option_test.go
@@ -1934,6 +1934,17 @@ func TestWithResourceIndicators(t *testing.T) {
 	}
 }
 
+func TestWithResourceIndicatorsRejectsInvalidAbsoluteURIs(t *testing.T) {
+	for _, resource := range []string{"", "/relative", "https://resource.com/path#fragment"} {
+		t.Run(resource, func(t *testing.T) {
+			p := &Provider{config: oidc.Configuration{}}
+			if err := WithResourceIndicators([]string{resource})(p); err == nil {
+				t.Fatalf("WithResourceIndicators(%q) error = nil, want invalid resource", resource)
+			}
+		})
+	}
+}
+
 func TestWithResourceIndicatorsRequired(t *testing.T) {
 	// Given.
 	p := &Provider{

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -412,34 +412,38 @@ func New(cfg Config, opts ...Option) (*Provider, error) {
 			}
 		}
 
-		if op.config.AuthCodeLifetimeSecs > 60 {
-			return nil, errors.New("[FAPI 2.0 5.3.1] authorization code lifetime must be less than 60 seconds")
-		}
+		if slices.Contains(op.config.GrantTypes, goidc.GrantAuthorizationCode) {
+			if slices.ContainsFunc(op.config.ResponseTypes, func(responseType goidc.ResponseType) bool {
+				return responseType != goidc.ResponseTypeCode
+			}) {
+				return nil, errors.New("[FAPI 2.0 5.3.2.2] only the code response type may be enabled")
+			}
 
-		if !slices.Contains(op.config.GrantTypes, goidc.GrantAuthorizationCode) {
-			return nil, errors.New("[FAPI 2.0 5.3.1] authorization_code grant must be required")
-		}
+			if op.config.AuthCodeLifetimeSecs > 60 {
+				return nil, errors.New("[FAPI 2.0 5.3.1] authorization code lifetime must be less than 60 seconds")
+			}
 
-		if !op.config.PARRequired {
-			return nil, errors.New("[FAPI 2.0 5.3.1] pushed authorization request must be required")
-		}
+			if !op.config.PARRequired {
+				return nil, errors.New("[FAPI 2.0 5.3.1] pushed authorization request must be required")
+			}
 
-		if !op.config.PKCERequired {
-			return nil, errors.New("[FAPI 2.0 5.3.1] pkce must be required")
-		}
+			if !op.config.PKCERequired {
+				return nil, errors.New("[FAPI 2.0 5.3.1] pkce must be required")
+			}
 
-		if slices.ContainsFunc(op.config.PKCEChallengeMethods, func(method goidc.CodeChallengeMethod) bool {
-			return method != goidc.CodeChallengeMethodSHA256
-		}) {
-			return nil, errors.New("[FAPI 2.0 5.3.1] only pkce S256 code challenge method must be available")
-		}
+			if slices.ContainsFunc(op.config.PKCEChallengeMethods, func(method goidc.CodeChallengeMethod) bool {
+				return method != goidc.CodeChallengeMethodSHA256
+			}) {
+				return nil, errors.New("[FAPI 2.0 5.3.1] only pkce S256 code challenge method must be available")
+			}
 
-		if !op.config.IssuerRespParamEnabled {
-			return nil, errors.New("[FAPI 2.0 5.3.1] pkce must be enabled")
-		}
+			if !op.config.IssuerRespParamEnabled {
+				return nil, errors.New("[FAPI 2.0 5.3.1] issuer response parameter must be enabled")
+			}
 
-		if op.config.PARLifetimeSecs > 600 {
-			return nil, errors.New("[FAPI 2.0 5.3.1] par request_uri lifetime must be less than 600 seconds")
+			if op.config.PARLifetimeSecs >= 600 {
+				return nil, errors.New("[FAPI 2.0 5.3.1] par request_uri lifetime must be less than 600 seconds")
+			}
 		}
 	}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -260,6 +260,106 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNewFAPI2ClientCredentialsOnly(t *testing.T) {
+	jwk := oidctest.PrivatePS256JWK(t, "test_server_key", goidc.KeyUsageSignature)
+
+	_, err := New(Config{
+		Issuer: "https://example.com",
+		JWKS: func(context.Context) (goidc.JSONWebKeySet, error) {
+			return goidc.JSONWebKeySet{Keys: []goidc.JSONWebKey{jwk}}, nil
+		},
+		IDTokenAlgs: []goidc.SignatureAlgorithm{goidc.SigAlgPS256},
+	},
+		WithProfile(goidc.ProfileFAPI2, WithProfileValidation()),
+		WithClientCredentialsGrant(),
+		WithPrivateKeyJWTAuthn(goidc.SigAlgPS256),
+		WithDPoP([]goidc.SignatureAlgorithm{goidc.SigAlgES256}, WithDPoPRequired()),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+}
+
+func TestNewFAPI2AuthorizationCodeStillRequiresPAR(t *testing.T) {
+	jwk := oidctest.PrivatePS256JWK(t, "test_server_key", goidc.KeyUsageSignature)
+
+	_, err := New(Config{
+		Issuer: "https://example.com",
+		JWKS: func(context.Context) (goidc.JSONWebKeySet, error) {
+			return goidc.JSONWebKeySet{Keys: []goidc.JSONWebKey{jwk}}, nil
+		},
+		IDTokenAlgs: []goidc.SignatureAlgorithm{goidc.SigAlgPS256},
+	},
+		WithProfile(goidc.ProfileFAPI2, WithProfileValidation()),
+		WithAuthCodeGrant(
+			AuthCodeGrantConfig{ResponseTypes: []goidc.ResponseType{goidc.ResponseTypeCode}},
+			WithPKCE([]goidc.CodeChallengeMethod{goidc.CodeChallengeMethodSHA256}, WithPKCERequired()),
+			WithIssuerResponseParameter(),
+		),
+		WithPrivateKeyJWTAuthn(goidc.SigAlgPS256),
+		WithDPoP([]goidc.SignatureAlgorithm{goidc.SigAlgES256}, WithDPoPRequired()),
+	)
+	if err == nil || err.Error() != "[FAPI 2.0 5.3.1] pushed authorization request must be required" {
+		t.Fatalf("New() error = %v, want missing PAR error", err)
+	}
+}
+
+func TestNewFAPI2AuthorizationCodeRequiresCodeResponseTypeOnly(t *testing.T) {
+	_, err := newFAPI2AuthorizationCodeProvider(
+		t,
+		[]goidc.ResponseType{goidc.ResponseType("code custom")},
+		599,
+	)
+	if err == nil || err.Error() != "[FAPI 2.0 5.3.2.2] only the code response type may be enabled" {
+		t.Fatalf("New() error = %v, want response type error", err)
+	}
+}
+
+func TestNewFAPI2AuthorizationCodeRequiresPARLifetimeBelow600Seconds(t *testing.T) {
+	if _, err := newFAPI2AuthorizationCodeProvider(
+		t,
+		[]goidc.ResponseType{goidc.ResponseTypeCode},
+		599,
+	); err != nil {
+		t.Fatalf("New() with 599 second PAR lifetime error = %v", err)
+	}
+
+	_, err := newFAPI2AuthorizationCodeProvider(
+		t,
+		[]goidc.ResponseType{goidc.ResponseTypeCode},
+		600,
+	)
+	if err == nil || err.Error() != "[FAPI 2.0 5.3.1] par request_uri lifetime must be less than 600 seconds" {
+		t.Fatalf("New() with 600 second PAR lifetime error = %v, want lifetime error", err)
+	}
+}
+
+func newFAPI2AuthorizationCodeProvider(
+	t *testing.T,
+	responseTypes []goidc.ResponseType,
+	parLifetime int,
+) (*Provider, error) {
+	t.Helper()
+	jwk := oidctest.PrivatePS256JWK(t, "test_server_key", goidc.KeyUsageSignature)
+	return New(Config{
+		Issuer: "https://example.com",
+		JWKS: func(context.Context) (goidc.JSONWebKeySet, error) {
+			return goidc.JSONWebKeySet{Keys: []goidc.JSONWebKey{jwk}}, nil
+		},
+		IDTokenAlgs: []goidc.SignatureAlgorithm{goidc.SigAlgPS256},
+	},
+		WithProfile(goidc.ProfileFAPI2, WithProfileValidation()),
+		WithAuthCodeGrant(
+			AuthCodeGrantConfig{ResponseTypes: responseTypes},
+			WithPKCE([]goidc.CodeChallengeMethod{goidc.CodeChallengeMethodSHA256}, WithPKCERequired()),
+			WithIssuerResponseParameter(),
+			WithPAR(nil, WithPARRequired(), WithPARLifetime(parLifetime)),
+		),
+		WithPrivateKeyJWTAuthn(goidc.SigAlgPS256),
+		WithDPoP([]goidc.SignatureAlgorithm{goidc.SigAlgES256}, WithDPoPRequired()),
+	)
+}
+
 func TestNew_DefaultsVCISelfBatchSize(t *testing.T) {
 	p, err := New(Config{
 		Issuer:      "https://example.com",


### PR DESCRIPTION
## Summary

- allow FAPI 2 providers that expose only machine-to-machine grants instead of requiring authorization_code
- when authorization_code is enabled, require code-only response types, PAR, PKCE S256, issuer response parameters, and a PAR lifetime below 600 seconds
- enforce required RFC 8707 resources for client_credentials
- validate configured resource indicators as unique absolute URIs without fragments and defensively copy configuration
- return unauthorized_client as HTTP 400 at the token endpoint without changing protected-resource 401 behavior

## Verification

- go test ./...
- go test -race ./internal/token ./pkg/provider ./pkg/goidc ./internal/userinfo
- go vet ./...
- golangci-lint run
- git diff --check

References: FAPI 2.0 Security Profile, RFC 8707, and RFC 6749 token endpoint error semantics.
