### PR TITLE
feat: add server-provided DPoP nonces

### DIFF
--- a/README.md
+++ b/README.md
@@ -978,12 +978,12 @@ If the client also provides the singular field, it must be present in the priori
 ## [Demonstrating Proof of Possession (DPoP)](https://www.rfc-editor.org/rfc/rfc9449.html)
 
 DPoP is enabled with `provider.WithDPoP(...)` and can be made mandatory with
-`provider.DPoPRequired()`.
+`provider.WithDPoPRequired()`.
 
 ```go
 op, _ := provider.New(
   ...,
-  provider.WithDPoP([]goidc.SignatureAlgorithm{goidc.ES256}),
+  provider.WithDPoP([]goidc.SignatureAlgorithm{goidc.SigAlgES256}),
   ...,
 )
 ```
@@ -1002,6 +1002,32 @@ enabled:
 - authorization requests, including PAR
 - token issuance
 - token usage and proof-of-possession validation
+
+Server-provided nonces can be enabled with a `goidc.DPoPNonceManager`:
+
+```go
+provider.WithDPoP(
+  []goidc.SignatureAlgorithm{goidc.SigAlgES256},
+  provider.WithDPoPNonce(nonceManager),
+)
+```
+
+The manager issues unpredictable nonces and validates them independently for
+authorization-server and resource-server scopes. In a multi-instance
+deployment, it should use shared state and retain a window of recent nonces for
+concurrent requests. Reusable recent nonces are supported; a manager that
+chooses single-use nonces must validate and consume them atomically. It can
+optionally return a replacement nonce to rotate it on a successful response.
+Unknown or expired nonces produce the RFC 9449 `use_dpop_nonce` challenge;
+storage failures fail closed as internal errors.
+Nonce handling does not replace `provider.WithJTIConsumer`; JTI tracking
+remains the replay-control mechanism for individual DPoP proofs.
+Browser-facing CORS middleware must expose `DPoP-Nonce` and, for protected
+resources, `WWW-Authenticate` to clients.
+
+RFC 9449 does not define separate discovery metadata for nonce support. DPoP
+algorithm support continues to be advertised through
+`dpop_signing_alg_values_supported`.
 
 ## Mutual TLS (mTLS)
 

--- a/internal/authorize/validation.go
+++ b/internal/authorize/validation.go
@@ -563,6 +563,7 @@ func validateCodeBindingDPoP(ctx oidc.Context, params goidc.AuthorizationParamet
 	return dpop.ValidateJWT(ctx, dpopJWT, dpop.ValidationOptions{
 		// "dpop_jkt" is optional, but it must match the DPoP JWT if present.
 		JWKThumbprint: params.DPoPJKT,
+		NonceScope:    goidc.DPoPNonceScopeAuthorizationServer,
 	})
 }
 

--- a/internal/dpop/nonce_test.go
+++ b/internal/dpop/nonce_test.go
@@ -1,0 +1,478 @@
+package dpop_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/luikyv/go-oidc/internal/dpop"
+	"github.com/luikyv/go-oidc/internal/oidc"
+	"github.com/luikyv/go-oidc/internal/oidctest"
+	"github.com/luikyv/go-oidc/pkg/goidc"
+)
+
+func TestValidateJWTDPoPNonceChallenge(t *testing.T) {
+	tests := []struct {
+		name       string
+		scope      goidc.DPoPNonceScope
+		wantStatus int
+		wantAuthn  bool
+	}{
+		{
+			name:       "authorization server",
+			scope:      goidc.DPoPNonceScopeAuthorizationServer,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "resource server",
+			scope:      goidc.DPoPNonceScopeResourceServer,
+			wantStatus: http.StatusUnauthorized,
+			wantAuthn:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			manager := newNonceManager("fresh_nonce")
+			ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+			consumeCalls := 0
+			ctx.ConsumeJTIFunc = func(context.Context, string) error {
+				consumeCalls++
+				return nil
+			}
+			rec.Header().Add(goidc.HeaderDPoPNonce, "stale_nonce_1")
+			rec.Header().Add(goidc.HeaderDPoPNonce, "stale_nonce_2")
+			proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method: http.MethodPost,
+				URI:    ctx.Host + "/token",
+			})
+
+			err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{NonceScope: test.scope})
+
+			assertOAuthError(t, err, goidc.ErrorCodeUseDPoPNonce, test.wantStatus)
+			if got := rec.Header().Values(goidc.HeaderDPoPNonce); len(got) != 1 || got[0] != "fresh_nonce" {
+				t.Fatalf("%s = %v, want [fresh_nonce]", goidc.HeaderDPoPNonce, got)
+			}
+			if got := rec.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+				t.Fatalf("Cache-Control = %q, want no-store", got)
+			}
+			authn := rec.Header().Get("WWW-Authenticate")
+			if test.wantAuthn && !strings.Contains(authn, `DPoP error="use_dpop_nonce"`) {
+				t.Fatalf("WWW-Authenticate = %q, want DPoP nonce challenge", authn)
+			}
+			if !test.wantAuthn && authn != "" {
+				t.Fatalf("WWW-Authenticate = %q, want empty", authn)
+			}
+			if manager.validateCallCount() != 0 {
+				t.Fatalf("ValidateNonce() calls = %d, want 0", manager.validateCallCount())
+			}
+			if consumeCalls != 0 {
+				t.Fatalf("ConsumeJTI() calls = %d, want 0", consumeCalls)
+			}
+		})
+	}
+}
+
+func TestValidateJWTDPoPNonceAcceptsRecentNonce(t *testing.T) {
+	for _, scope := range []goidc.DPoPNonceScope{
+		goidc.DPoPNonceScopeAuthorizationServer,
+		goidc.DPoPNonceScopeResourceServer,
+	} {
+		t.Run(string(scope), func(t *testing.T) {
+			manager := newNonceManager()
+			manager.add(scope, "current_nonce")
+			ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+			proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method: http.MethodPost,
+				URI:    ctx.Host + "/token",
+				Nonce:  "current_nonce",
+			})
+
+			err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{NonceScope: scope})
+
+			if err != nil {
+				t.Fatalf("ValidateJWT() error = %v", err)
+			}
+			if got := rec.Header().Values(goidc.HeaderDPoPNonce); len(got) != 0 {
+				t.Fatalf("%s = %v, want no rotation", goidc.HeaderDPoPNonce, got)
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("WWW-Authenticate = %q, want empty", got)
+			}
+			if !manager.has(scope, "current_nonce") {
+				t.Fatal("the reusable nonce was unexpectedly consumed")
+			}
+		})
+	}
+}
+
+func TestValidateJWTDPoPNoncePositiveResponseRotation(t *testing.T) {
+	manager := newNonceManager()
+	manager.nextValues = []string{"next_nonce"}
+	manager.add(goidc.DPoPNonceScopeAuthorizationServer, "current_nonce")
+	ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    ctx.Host + "/token",
+		Nonce:  "current_nonce",
+	})
+
+	err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+		NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+	})
+
+	if err != nil {
+		t.Fatalf("ValidateJWT() error = %v", err)
+	}
+	if got := rec.Header().Values(goidc.HeaderDPoPNonce); len(got) != 1 || got[0] != "next_nonce" {
+		t.Fatalf("%s = %v, want [next_nonce]", goidc.HeaderDPoPNonce, got)
+	}
+	if got := rec.Header().Get("Cache-Control"); !strings.Contains(got, "no-store") {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if !manager.has(goidc.DPoPNonceScopeAuthorizationServer, "next_nonce") {
+		t.Fatal("the replacement nonce was not persisted before validation returned")
+	}
+}
+
+func TestValidateJWTDPoPNonceMismatch(t *testing.T) {
+	manager := newNonceManager("replacement_nonce")
+	ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+	consumeCalls := 0
+	ctx.ConsumeJTIFunc = func(context.Context, string) error {
+		consumeCalls++
+		return nil
+	}
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    ctx.Host + "/token",
+		Nonce:  "unknown_nonce",
+	})
+
+	err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+		NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+	})
+
+	assertOAuthError(t, err, goidc.ErrorCodeUseDPoPNonce, http.StatusBadRequest)
+	if got := rec.Header().Get(goidc.HeaderDPoPNonce); got != "replacement_nonce" {
+		t.Fatalf("%s = %q, want replacement_nonce", goidc.HeaderDPoPNonce, got)
+	}
+	if consumeCalls != 0 {
+		t.Fatalf("ConsumeJTI() calls = %d, want 0", consumeCalls)
+	}
+}
+
+func TestValidateJWTDPoPNonceIsScopedToIssuer(t *testing.T) {
+	manager := newNonceManager("resource_nonce")
+	manager.add(goidc.DPoPNonceScopeAuthorizationServer, "authorization_nonce")
+	ctx, _ := nonceContext(t, manager, http.MethodGet, "/userinfo")
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodGet,
+		URI:    ctx.Host + "/userinfo",
+		Nonce:  "authorization_nonce",
+	})
+
+	err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+		NonceScope: goidc.DPoPNonceScopeResourceServer,
+	})
+
+	assertOAuthError(t, err, goidc.ErrorCodeUseDPoPNonce, http.StatusUnauthorized)
+}
+
+func TestValidateJWTDPoPNonceOperationalErrorsFailClosed(t *testing.T) {
+	storeErr := errors.New("nonce store unavailable")
+
+	t.Run("validate", func(t *testing.T) {
+		manager := newNonceManager("unused_nonce")
+		manager.add(goidc.DPoPNonceScopeAuthorizationServer, "current_nonce")
+		manager.validateErr = storeErr
+		ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+		consumeCalls := 0
+		ctx.ConsumeJTIFunc = func(context.Context, string) error {
+			consumeCalls++
+			return nil
+		}
+		proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+			Method: http.MethodPost,
+			URI:    ctx.Host + "/token",
+			Nonce:  "current_nonce",
+		})
+
+		err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+			NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+		})
+
+		if !errors.Is(err, storeErr) {
+			t.Fatalf("ValidateJWT() error = %v, want wrapped store error", err)
+		}
+		assertNotNonceChallenge(t, err, rec)
+		if manager.issueCallCount() != 0 {
+			t.Fatalf("IssueNonce() calls = %d, want 0", manager.issueCallCount())
+		}
+		if consumeCalls != 0 {
+			t.Fatalf("ConsumeJTI() calls = %d, want 0", consumeCalls)
+		}
+	})
+
+	t.Run("issue challenge", func(t *testing.T) {
+		manager := newNonceManager()
+		manager.issueErr = storeErr
+		ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+		proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+			Method: http.MethodPost,
+			URI:    ctx.Host + "/token",
+		})
+
+		err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+			NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+		})
+
+		if !errors.Is(err, storeErr) {
+			t.Fatalf("ValidateJWT() error = %v, want wrapped store error", err)
+		}
+		assertNotNonceChallenge(t, err, rec)
+	})
+
+	t.Run("invalid issued nonce", func(t *testing.T) {
+		manager := newNonceManager("not a valid nonce")
+		ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+		proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+			Method: http.MethodPost,
+			URI:    ctx.Host + "/token",
+		})
+
+		err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+			NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+		})
+
+		if err == nil || !strings.Contains(err.Error(), "invalid DPoP nonce") {
+			t.Fatalf("ValidateJWT() error = %v, want invalid nonce error", err)
+		}
+		assertNotNonceChallenge(t, err, rec)
+	})
+
+	t.Run("invalid positive-response nonce", func(t *testing.T) {
+		manager := newNonceManager()
+		manager.nextValues = []string{"not a valid nonce"}
+		manager.add(goidc.DPoPNonceScopeAuthorizationServer, "current_nonce")
+		ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+		proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+			Method: http.MethodPost,
+			URI:    ctx.Host + "/token",
+			Nonce:  "current_nonce",
+		})
+
+		err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+			NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+		})
+
+		if err == nil || !strings.Contains(err.Error(), "invalid DPoP nonce") {
+			t.Fatalf("ValidateJWT() error = %v, want invalid nonce error", err)
+		}
+		assertNotNonceChallenge(t, err, rec)
+	})
+}
+
+func TestValidateJWTDPoPNonceMissingScopeFailsClosed(t *testing.T) {
+	manager := newNonceManager("unused_nonce")
+	ctx, rec := nonceContext(t, manager, http.MethodPost, "/token")
+	proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    ctx.Host + "/token",
+	})
+
+	err := dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{})
+
+	if err == nil || !strings.Contains(err.Error(), "nonce scope") {
+		t.Fatalf("ValidateJWT() error = %v, want missing nonce scope error", err)
+	}
+	assertNotNonceChallenge(t, err, rec)
+	if manager.issueCallCount() != 0 || manager.validateCallCount() != 0 {
+		t.Fatalf("nonce manager calls = issue %d, validate %d; want none", manager.issueCallCount(), manager.validateCallCount())
+	}
+}
+
+func TestValidateJWTDPoPNonceConcurrentConsumption(t *testing.T) {
+	const requestCount = 16
+	manager := newNonceManager()
+	manager.singleUse = true
+	manager.add(goidc.DPoPNonceScopeAuthorizationServer, "shared_nonce")
+
+	proofs := make([]string, requestCount)
+	contexts := make([]oidc.Context, requestCount)
+	for i := range proofs {
+		proofs[i], _ = oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+			Method: http.MethodPost,
+			URI:    "https://example.com/token",
+			Nonce:  "shared_nonce",
+		})
+		contexts[i], _ = nonceContext(t, manager, http.MethodPost, "/token")
+	}
+
+	start := make(chan struct{})
+	results := make(chan error, requestCount)
+	var wg sync.WaitGroup
+	for i, proof := range proofs {
+		ctx := contexts[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- dpop.ValidateJWT(ctx, proof, dpop.ValidationOptions{
+				NonceScope: goidc.DPoPNonceScopeAuthorizationServer,
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var successes int
+	for err := range results {
+		if err == nil {
+			successes++
+			continue
+		}
+		var oauthErr goidc.Error
+		if !errors.As(err, &oauthErr) || oauthErr.Code != goidc.ErrorCodeUseDPoPNonce {
+			t.Fatalf("concurrent ValidateJWT() error = %v, want use_dpop_nonce", err)
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful concurrent consumptions = %d, want 1", successes)
+	}
+}
+
+func nonceContext(t *testing.T, manager goidc.DPoPNonceManager, method, path string) (oidc.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	base := oidctest.NewContext(t)
+	base.DPoPEnabled = true
+	base.DPoPSigAlgs = []goidc.SignatureAlgorithm{goidc.SigAlgES256}
+	base.DPoPNonceManager = manager
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	return oidc.NewHTTPContext(rec, req, base.Configuration), rec
+}
+
+func assertOAuthError(t *testing.T, err error, code goidc.ErrorCode, status int) {
+	t.Helper()
+	var oauthErr goidc.Error
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("error = %v, want OAuth error", err)
+	}
+	if oauthErr.Code != code {
+		t.Fatalf("error code = %q, want %q", oauthErr.Code, code)
+	}
+	if oauthErr.StatusCode() != status {
+		t.Fatalf("status = %d, want %d", oauthErr.StatusCode(), status)
+	}
+}
+
+func assertNotNonceChallenge(t *testing.T, err error, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	var oauthErr goidc.Error
+	if errors.As(err, &oauthErr) && oauthErr.Code == goidc.ErrorCodeUseDPoPNonce {
+		t.Fatalf("error = %v, must not be a nonce challenge", err)
+	}
+	if got := rec.Header().Get(goidc.HeaderDPoPNonce); got != "" {
+		t.Fatalf("%s = %q, want empty", goidc.HeaderDPoPNonce, got)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+		t.Fatalf("WWW-Authenticate = %q, want empty", got)
+	}
+}
+
+type nonceManager struct {
+	mu            sync.Mutex
+	valid         map[nonceKey]struct{}
+	issueValues   []string
+	nextValues    []string
+	issueCalls    int
+	validateCalls int
+	nextCalls     int
+	singleUse     bool
+	issueErr      error
+	validateErr   error
+}
+
+type nonceKey struct {
+	scope goidc.DPoPNonceScope
+	nonce string
+}
+
+func newNonceManager(issueValues ...string) *nonceManager {
+	return &nonceManager{
+		valid:       make(map[nonceKey]struct{}),
+		issueValues: issueValues,
+	}
+}
+
+func (m *nonceManager) IssueNonce(_ context.Context, scope goidc.DPoPNonceScope) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.issueCalls++
+	if m.issueErr != nil {
+		return "", m.issueErr
+	}
+
+	nonce := fmt.Sprintf("fresh_nonce_%d", m.issueCalls)
+	if m.issueCalls <= len(m.issueValues) {
+		nonce = m.issueValues[m.issueCalls-1]
+	}
+	m.valid[nonceKey{scope: scope, nonce: nonce}] = struct{}{}
+	return nonce, nil
+}
+
+func (m *nonceManager) ValidateNonce(_ context.Context, scope goidc.DPoPNonceScope, nonce string) (goidc.DPoPNonceValidation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.validateCalls++
+	if m.validateErr != nil {
+		return goidc.DPoPNonceValidation{}, m.validateErr
+	}
+
+	key := nonceKey{scope: scope, nonce: nonce}
+	if _, ok := m.valid[key]; !ok {
+		return goidc.DPoPNonceValidation{}, goidc.ErrNotFound
+	}
+	if m.singleUse {
+		delete(m.valid, key)
+	}
+	if m.nextCalls < len(m.nextValues) {
+		next := m.nextValues[m.nextCalls]
+		m.nextCalls++
+		m.valid[nonceKey{scope: scope, nonce: next}] = struct{}{}
+		return goidc.DPoPNonceValidation{NextNonce: next}, nil
+	}
+	return goidc.DPoPNonceValidation{}, nil
+}
+
+func (m *nonceManager) add(scope goidc.DPoPNonceScope, nonce string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.valid[nonceKey{scope: scope, nonce: nonce}] = struct{}{}
+}
+
+func (m *nonceManager) has(scope goidc.DPoPNonceScope, nonce string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.valid[nonceKey{scope: scope, nonce: nonce}]
+	return ok
+}
+
+func (m *nonceManager) issueCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.issueCalls
+}
+
+func (m *nonceManager) validateCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.validateCalls
+}

--- a/internal/dpop/util.go
+++ b/internal/dpop/util.go
@@ -4,8 +4,11 @@ import (
 	"crypto"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -20,12 +23,14 @@ type ValidationOptions struct {
 	// AccessToken should be filled when the DPoP "ath" claim is expected and should be validated.
 	AccessToken   string
 	JWKThumbprint string
+	NonceScope    goidc.DPoPNonceScope
 }
 
 type Claims struct {
 	HTTPMethod      string `json:"htm"`
 	HTTPURI         string `json:"htu"`
 	AccessTokenHash string `json:"ath"`
+	Nonce           string `json:"nonce"`
 }
 
 // JWKThumbprint generates a JWK thumbprint for a valid DPoP JWT.
@@ -95,10 +100,6 @@ func ValidateJWT(ctx oidc.Context, dpopJWT string, opts ValidationOptions) error
 			errors.New("the jti claim is required"))
 	}
 
-	if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
-		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
-	}
-
 	if dpopClaims.HTTPMethod != ctx.RequestMethod() {
 		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof",
 			errors.New("the htm claim does not match the request method"))
@@ -128,5 +129,105 @@ func ValidateJWT(ctx oidc.Context, dpopJWT string, opts ValidationOptions) error
 		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
 	}
 
+	if ctx.DPoPNonceManager != nil {
+		if opts.NonceScope == "" {
+			return errors.New("a DPoP nonce scope is required when nonce validation is enabled")
+		}
+		if err := validateNonce(ctx, opts.NonceScope, dpopClaims.Nonce); err != nil {
+			return err
+		}
+	}
+
+	if err := ctx.ConsumeJTI(claims.ID); err != nil && !errors.Is(err, goidc.ErrNotFound) {
+		return goidc.WrapError(goidc.ErrorCodeInvalidRequest, "invalid DPoP proof", err)
+	}
+
 	return nil
+}
+
+func validateNonce(ctx oidc.Context, scope goidc.DPoPNonceScope, nonce string) error {
+	if scope != goidc.DPoPNonceScopeAuthorizationServer && scope != goidc.DPoPNonceScopeResourceServer {
+		return fmt.Errorf("invalid DPoP nonce scope %q", scope)
+	}
+	if ctx.Response == nil {
+		return errors.New("cannot use DPoP nonces without a response writer")
+	}
+
+	if !validNonce(nonce) {
+		return nonceChallenge(ctx, scope)
+	}
+
+	validation, err := ctx.ValidateDPoPNonce(scope, nonce)
+	if err != nil {
+		if errors.Is(err, goidc.ErrNotFound) {
+			return nonceChallenge(ctx, scope)
+		}
+		return fmt.Errorf("could not validate DPoP nonce: %w", err)
+	}
+	if validation.NextNonce == "" {
+		return nil
+	}
+	return setNonceHeader(ctx, validation.NextNonce)
+}
+
+func nonceChallenge(ctx oidc.Context, scope goidc.DPoPNonceScope) error {
+	if _, err := issueNonce(ctx, scope); err != nil {
+		return err
+	}
+
+	description := "authorization server requires a fresh nonce in the DPoP proof"
+	status := http.StatusBadRequest
+	if scope == goidc.DPoPNonceScopeResourceServer {
+		description = "resource server requires a fresh nonce in the DPoP proof"
+		status = http.StatusUnauthorized
+		challenge := "DPoP error=" + strconv.Quote(string(goidc.ErrorCodeUseDPoPNonce)) +
+			", error_description=" + strconv.Quote(description)
+		if len(ctx.DPoPSigAlgs) != 0 {
+			algs := make([]string, len(ctx.DPoPSigAlgs))
+			for i, alg := range ctx.DPoPSigAlgs {
+				algs[i] = string(alg)
+			}
+			challenge += ", algs=" + strconv.Quote(strings.Join(algs, " "))
+		}
+		ctx.Response.Header().Add("WWW-Authenticate", challenge)
+	}
+
+	return goidc.NewError(goidc.ErrorCodeUseDPoPNonce, description).WithStatusCode(status)
+}
+
+func issueNonce(ctx oidc.Context, scope goidc.DPoPNonceScope) (string, error) {
+	nonce, err := ctx.IssueDPoPNonce(scope)
+	if err != nil {
+		return "", fmt.Errorf("could not issue DPoP nonce: %w", err)
+	}
+	if err := setNonceHeader(ctx, nonce); err != nil {
+		return "", err
+	}
+	return nonce, nil
+}
+
+func setNonceHeader(ctx oidc.Context, nonce string) error {
+	if !validNonce(nonce) {
+		return errors.New("DPoP nonce manager issued an invalid DPoP nonce")
+	}
+	// Set, rather than Add, guarantees that the response never contains more
+	// than one DPoP-Nonce field value as required by RFC 9449 Section 8.
+	ctx.Response.Header().Set(goidc.HeaderDPoPNonce, nonce)
+	ctx.Response.Header().Set("Cache-Control", "no-store")
+	return nil
+}
+
+func validNonce(nonce string) bool {
+	if nonce == "" {
+		return false
+	}
+
+	for i := range len(nonce) {
+		c := nonce[i]
+		if c == 0x21 || (c >= 0x23 && c <= 0x5b) || (c >= 0x5d && c <= 0x7e) {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/oidc/config.go
+++ b/internal/oidc/config.go
@@ -190,6 +190,8 @@ type Configuration struct {
 	DPoPEnabled  bool
 	DPoPRequired bool
 	DPoPSigAlgs  []goidc.SignatureAlgorithm
+	// DPoPNonceManager enables server-provided DPoP nonces.
+	DPoPNonceManager goidc.DPoPNonceManager
 
 	PKCEEnabled                bool
 	PKCERequired               bool

--- a/internal/oidc/context.go
+++ b/internal/oidc/context.go
@@ -121,6 +121,14 @@ func (ctx Context) ConsumeJTI(jti string) error {
 	return ctx.ConsumeJTIFunc(ctx, jti)
 }
 
+func (ctx Context) IssueDPoPNonce(scope goidc.DPoPNonceScope) (string, error) {
+	return ctx.DPoPNonceManager.IssueNonce(ctx, scope)
+}
+
+func (ctx Context) ValidateDPoPNonce(scope goidc.DPoPNonceScope, nonce string) (goidc.DPoPNonceValidation, error) {
+	return ctx.DPoPNonceManager.ValidateNonce(ctx, scope, nonce)
+}
+
 func (ctx Context) RenderError(err error) error {
 	if ctx.RenderErrorFunc == nil {
 		// No need to notify error here, since this error will end up being

--- a/internal/oidctest/dpop_nonce.go
+++ b/internal/oidctest/dpop_nonce.go
@@ -1,0 +1,72 @@
+package oidctest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/luikyv/go-oidc/pkg/goidc"
+)
+
+type DPoPNonceManager struct {
+	mu          sync.Mutex
+	valid       map[dpopNonceKey]struct{}
+	issueValues []string
+	issueCalls  int
+	nextValues  []string
+	nextCalls   int
+}
+
+type dpopNonceKey struct {
+	scope goidc.DPoPNonceScope
+	nonce string
+}
+
+func NewDPoPNonceManager(issueValues ...string) *DPoPNonceManager {
+	return &DPoPNonceManager{
+		valid:       make(map[dpopNonceKey]struct{}),
+		issueValues: issueValues,
+	}
+}
+
+func (m *DPoPNonceManager) Add(scope goidc.DPoPNonceScope, nonce string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.valid[dpopNonceKey{scope: scope, nonce: nonce}] = struct{}{}
+}
+
+func (m *DPoPNonceManager) RotateWith(nonces ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextValues = nonces
+}
+
+func (m *DPoPNonceManager) IssueNonce(_ context.Context, scope goidc.DPoPNonceScope) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.issueCalls++
+
+	nonce := fmt.Sprintf("fresh_nonce_%d", m.issueCalls)
+	if m.issueCalls <= len(m.issueValues) {
+		nonce = m.issueValues[m.issueCalls-1]
+	}
+	m.valid[dpopNonceKey{scope: scope, nonce: nonce}] = struct{}{}
+	return nonce, nil
+}
+
+func (m *DPoPNonceManager) ValidateNonce(_ context.Context, scope goidc.DPoPNonceScope, nonce string) (goidc.DPoPNonceValidation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := dpopNonceKey{scope: scope, nonce: nonce}
+	if _, ok := m.valid[key]; !ok {
+		return goidc.DPoPNonceValidation{}, goidc.ErrNotFound
+	}
+	if m.nextCalls < len(m.nextValues) {
+		next := m.nextValues[m.nextCalls]
+		m.nextCalls++
+		m.valid[dpopNonceKey{scope: scope, nonce: next}] = struct{}{}
+		return goidc.DPoPNonceValidation{NextNonce: next}, nil
+	}
+	return goidc.DPoPNonceValidation{}, nil
+}

--- a/internal/oidctest/util.go
+++ b/internal/oidctest/util.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
+	"github.com/luikyv/go-oidc/internal/hashutil"
 	"github.com/luikyv/go-oidc/internal/joseutil"
 	"github.com/luikyv/go-oidc/internal/oidc"
 	"github.com/luikyv/go-oidc/internal/storage"
@@ -404,8 +405,10 @@ func Sign(tb testing.TB, claims map[string]any, jwk goidc.JSONWebKey) string {
 
 // DPoPProofOptions configures DPoP proof generation.
 type DPoPProofOptions struct {
-	Method string
-	URI    string
+	Method      string
+	URI         string
+	AccessToken string
+	Nonce       string
 	// Key is the private key used to sign the proof. If nil, a fresh ES256 key
 	// is generated.
 	Key crypto.PrivateKey
@@ -458,6 +461,12 @@ func DPoPProof(tb testing.TB, opts DPoPProofOptions) (dpopJWT string, thumbprint
 		"htm": opts.Method,
 		"htu": opts.URI,
 		"iat": time.Now().Unix(),
+	}
+	if opts.AccessToken != "" {
+		claims["ath"] = hashutil.Thumbprint(opts.AccessToken)
+	}
+	if opts.Nonce != "" {
+		claims["nonce"] = opts.Nonce
 	}
 	payload, err := json.Marshal(claims)
 	if err != nil {

--- a/internal/token/api_test.go
+++ b/internal/token/api_test.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -182,4 +183,156 @@ func TestTokenHandlersInvalidContentType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTokenEndpointDPoPNonce(t *testing.T) {
+	tests := []struct {
+		name       string
+		nonce      string
+		rotateTo   string
+		wantStatus int
+		wantNonce  string
+		wantError  goidc.ErrorCode
+	}{
+		{
+			name:       "challenge",
+			wantStatus: http.StatusBadRequest,
+			wantNonce:  "challenge_nonce",
+			wantError:  goidc.ErrorCodeUseDPoPNonce,
+		},
+		{
+			name:       "success with reusable nonce",
+			nonce:      "current_nonce",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "success rotates nonce when requested",
+			nonce:      "current_nonce",
+			rotateTo:   "next_nonce",
+			wantStatus: http.StatusOK,
+			wantNonce:  "next_nonce",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			ctx.DPoPEnabled = true
+			ctx.DPoPSigAlgs = []goidc.SignatureAlgorithm{goidc.SigAlgES256}
+			manager := oidctest.NewDPoPNonceManager(test.wantNonce)
+			ctx.DPoPNonceManager = manager
+			if test.nonce != "" {
+				manager.Add(goidc.DPoPNonceScopeAuthorizationServer, test.nonce)
+			}
+			if test.rotateTo != "" {
+				manager.RotateWith(test.rotateTo)
+			}
+
+			client, secret := oidctest.NewClient(t)
+			ctx.StaticClients = append(ctx.StaticClients, client)
+			form := url.Values{
+				"grant_type":    {string(goidc.GrantClientCredentials)},
+				"client_id":     {client.ID},
+				"client_secret": {secret},
+				"scope":         {"scope1"},
+			}
+			req := httptest.NewRequest(http.MethodPost, ctx.TokenEndpoint, strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method: http.MethodPost,
+				URI:    ctx.Host + ctx.TokenEndpoint,
+				Nonce:  test.nonce,
+			})
+			req.Header.Set(goidc.HeaderDPoP, proof)
+			rec := httptest.NewRecorder()
+			mux := http.NewServeMux()
+			RegisterHandlers(mux, ctx.Configuration)
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+			gotNonces := rec.Header().Values(goidc.HeaderDPoPNonce)
+			if test.wantNonce == "" && len(gotNonces) != 0 {
+				t.Fatalf("%s = %v, want empty", goidc.HeaderDPoPNonce, gotNonces)
+			}
+			if test.wantNonce != "" && (len(gotNonces) != 1 || gotNonces[0] != test.wantNonce) {
+				t.Fatalf("%s = %v, want [%s]", goidc.HeaderDPoPNonce, gotNonces, test.wantNonce)
+			}
+			if test.wantError != "" && !strings.Contains(rec.Body.String(), `"error":"`+string(test.wantError)+`"`) {
+				t.Fatalf("body = %s, want error %q", rec.Body.String(), test.wantError)
+			}
+			if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("WWW-Authenticate = %q, want empty", got)
+			}
+		})
+	}
+}
+
+func TestTokenEndpointDPoPNonceStoreFailure(t *testing.T) {
+	storeErr := errors.New("nonce store unavailable")
+	tests := []struct {
+		name  string
+		nonce string
+	}{
+		{name: "issue", nonce: ""},
+		{name: "validate", nonce: "current_nonce"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			ctx.DPoPEnabled = true
+			ctx.DPoPSigAlgs = []goidc.SignatureAlgorithm{goidc.SigAlgES256}
+			ctx.DPoPNonceManager = failingDPoPNonceManager{err: storeErr}
+			client, secret := oidctest.NewClient(t)
+			ctx.StaticClients = append(ctx.StaticClients, client)
+
+			form := url.Values{
+				"grant_type":    {string(goidc.GrantClientCredentials)},
+				"client_id":     {client.ID},
+				"client_secret": {secret},
+				"scope":         {"scope1"},
+			}
+			req := httptest.NewRequest(http.MethodPost, ctx.TokenEndpoint, strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method: http.MethodPost,
+				URI:    ctx.Host + ctx.TokenEndpoint,
+				Nonce:  test.nonce,
+			})
+			req.Header.Set(goidc.HeaderDPoP, proof)
+			rec := httptest.NewRecorder()
+			mux := http.NewServeMux()
+			RegisterHandlers(mux, ctx.Configuration)
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), `"error":"internal_error"`) {
+				t.Fatalf("body = %s, want internal_error", rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), string(goidc.ErrorCodeUseDPoPNonce)) {
+				t.Fatalf("body = %s, must not downgrade to use_dpop_nonce", rec.Body.String())
+			}
+			if got := rec.Header().Get(goidc.HeaderDPoPNonce); got != "" {
+				t.Fatalf("%s = %q, want empty", goidc.HeaderDPoPNonce, got)
+			}
+		})
+	}
+}
+
+type failingDPoPNonceManager struct {
+	err error
+}
+
+func (m failingDPoPNonceManager) IssueNonce(context.Context, goidc.DPoPNonceScope) (string, error) {
+	return "", m.err
+}
+
+func (m failingDPoPNonceManager) ValidateNonce(context.Context, goidc.DPoPNonceScope, string) (goidc.DPoPNonceValidation, error) {
+	return goidc.DPoPNonceValidation{}, m.err
 }

--- a/internal/token/pop.go
+++ b/internal/token/pop.go
@@ -13,7 +13,11 @@ import (
 // prove the client's possession of the token.
 // If token is omitted, the validation of the claim 'ath' of DPoP JWTs is skipped.
 func ValidatePoP(ctx oidc.Context, token string, cnf goidc.TokenConfirmation) error {
-	if err := validateDPoP(ctx, token, cnf); err != nil {
+	return validatePoP(ctx, token, cnf, goidc.DPoPNonceScopeResourceServer)
+}
+
+func validatePoP(ctx oidc.Context, token string, cnf goidc.TokenConfirmation, nonceScope goidc.DPoPNonceScope) error {
+	if err := validateDPoPWithNonceScope(ctx, token, cnf, nonceScope); err != nil {
 		return err
 	}
 
@@ -24,6 +28,10 @@ func ValidatePoP(ctx oidc.Context, token string, cnf goidc.TokenConfirmation) er
 // prove the client's possession of the access token with DPoP if applicable.
 // If token is omitted, the validation of the claim 'ath' of DPoP JWTs is skipped.
 func validateDPoP(ctx oidc.Context, token string, confirmation goidc.TokenConfirmation) error {
+	return validateDPoPWithNonceScope(ctx, token, confirmation, goidc.DPoPNonceScopeResourceServer)
+}
+
+func validateDPoPWithNonceScope(ctx oidc.Context, token string, confirmation goidc.TokenConfirmation, nonceScope goidc.DPoPNonceScope) error {
 	if confirmation.JWKThumbprint == "" {
 		return nil
 	}
@@ -42,6 +50,7 @@ func validateDPoP(ctx oidc.Context, token string, confirmation goidc.TokenConfir
 	return dpop.ValidateJWT(ctx, dpopJWT, dpop.ValidationOptions{
 		AccessToken:   token,
 		JWKThumbprint: confirmation.JWKThumbprint,
+		NonceScope:    nonceScope,
 	})
 }
 

--- a/internal/token/pre_auth_code.go
+++ b/internal/token/pre_auth_code.go
@@ -50,10 +50,6 @@ func generatePreAuthCodeToken(ctx oidc.Context, req request) (response, error) {
 		return response{}, goidc.WrapError(goidc.ErrorCodeUnauthorizedClient, "unauthorized client", errors.New("the client is not allowed to use the urn:ietf:params:oauth:grant-type:pre-authorized_code grant type"))
 	}
 
-	if err := ValidateBinding(ctx, c, nil); err != nil {
-		return response{}, err
-	}
-
 	if err := validateScopes(ctx, req, c, nil); err != nil {
 		return response{}, err
 	}
@@ -135,6 +131,9 @@ func generatePreAuthCodeToken(ctx oidc.Context, req request) (response, error) {
 		if !ctx.VCIExternalPreAuthCodeGrantEnabled {
 			return response{}, goidc.WrapError(goidc.ErrorCodeInvalidGrant, "invalid grant",
 				errors.New("external credential issuers do not support the pre-authorized code grant"))
+		}
+		if err := ValidateBinding(ctx, c, nil); err != nil {
+			return response{}, err
 		}
 
 		opts := goidc.VCPreAuthCodeOptions{

--- a/internal/token/pre_auth_code_test.go
+++ b/internal/token/pre_auth_code_test.go
@@ -3,6 +3,8 @@ package token
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/luikyv/go-oidc/internal/oidc"
@@ -10,6 +12,84 @@ import (
 	"github.com/luikyv/go-oidc/internal/timeutil"
 	"github.com/luikyv/go-oidc/pkg/goidc"
 )
+
+func TestGeneratePreAuthCodeTokenValidatesDPoPNonceOnce(t *testing.T) {
+	ctx := oidctest.NewContext(t)
+	ctx.GrantTypes = append(ctx.GrantTypes, goidc.GrantPreAuthorizedCode)
+	ctx.VCIPreAuthCodeAnonymousAccessEnabled = true
+	ctx.VCIEnabled = true
+	ctx.VCISelfEnabled = true
+	ctx.VCISelfPreAuthCodeGrantEnabled = true
+	ctx.VCISelfPreAuthCodeGrantManager = oidctest.Manager(t, ctx)
+	ctx.VCISelfHost = "https://issuer.example.com"
+	ctx.Scopes = []goidc.Scope{goidc.NewScope("vc_scope1")}
+	ctx.VCIIssuers = []goidc.VCIssuer{
+		{
+			Issuer: ctx.VCISelfHost,
+			Configurations: []goidc.VCConfiguration{
+				{ID: "cred1", Scope: goidc.NewScope("vc_scope1")},
+			},
+		},
+	}
+
+	nonceManager := &singleUseDPoPNonceManager{nonce: "current_nonce"}
+	ctx.DPoPEnabled = true
+	ctx.DPoPSigAlgs = []goidc.SignatureAlgorithm{goidc.SigAlgES256}
+	ctx.DPoPNonceManager = nonceManager
+	proof, thumbprint := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+		Method: http.MethodPost,
+		URI:    "https://example.com/token",
+		Nonce:  "current_nonce",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/token", nil)
+	req.Header.Set(goidc.HeaderDPoP, proof)
+	ctx = oidc.NewHTTPContext(httptest.NewRecorder(), req, ctx.Configuration)
+
+	grant := &goidc.Grant{
+		ID:                   "grant_id",
+		Subject:              "subject",
+		Scopes:               "vc_scope1",
+		PreAuthCode:          "pre_auth_code",
+		PreAuthCodeExpiresAt: timeutil.TimestampNow() + 60,
+		JWKThumbprint:        thumbprint,
+	}
+	if err := ctx.SaveGrant(grant); err != nil {
+		t.Fatalf("SaveGrant() error = %v", err)
+	}
+
+	resp, err := generatePreAuthCodeToken(ctx, request{
+		preAuthCode: "pre_auth_code",
+		scopes:      "vc_scope1",
+	})
+
+	if err != nil {
+		t.Fatalf("generatePreAuthCodeToken() error = %v", err)
+	}
+	if resp.AccessToken == "" {
+		t.Fatal("AccessToken is empty")
+	}
+	if nonceManager.validateCalls != 1 {
+		t.Fatalf("ValidateNonce() calls = %d, want 1", nonceManager.validateCalls)
+	}
+}
+
+type singleUseDPoPNonceManager struct {
+	nonce         string
+	validateCalls int
+}
+
+func (*singleUseDPoPNonceManager) IssueNonce(context.Context, goidc.DPoPNonceScope) (string, error) {
+	return "fresh_nonce", nil
+}
+
+func (m *singleUseDPoPNonceManager) ValidateNonce(_ context.Context, _ goidc.DPoPNonceScope, nonce string) (goidc.DPoPNonceValidation, error) {
+	m.validateCalls++
+	if nonce != m.nonce {
+		return goidc.DPoPNonceValidation{}, goidc.ErrNotFound
+	}
+	m.nonce = ""
+	return goidc.DPoPNonceValidation{}, nil
+}
 
 func TestGeneratePreAuthCodeToken(t *testing.T) {
 	tests := []struct {

--- a/internal/token/refresh_token.go
+++ b/internal/token/refresh_token.go
@@ -168,5 +168,5 @@ func validateRefreshTokenPoP(ctx oidc.Context, c *goidc.Client, cnf goidc.TokenC
 		return nil
 	}
 
-	return ValidatePoP(ctx, "", cnf)
+	return validatePoP(ctx, "", cnf, goidc.DPoPNonceScopeAuthorizationServer)
 }

--- a/internal/token/validation.go
+++ b/internal/token/validation.go
@@ -52,6 +52,7 @@ func validateBindingDPoP(ctx oidc.Context, c *goidc.Client, opts bindindValidati
 
 	return dpop.ValidateJWT(ctx, dpopJWT, dpop.ValidationOptions{
 		JWKThumbprint: opts.dpopJWKThumbprint,
+		NonceScope:    goidc.DPoPNonceScopeAuthorizationServer,
 	})
 }
 

--- a/internal/userinfo/api_test.go
+++ b/internal/userinfo/api_test.go
@@ -1,0 +1,133 @@
+package userinfo
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/luikyv/go-oidc/internal/oidc"
+	"github.com/luikyv/go-oidc/internal/oidctest"
+	"github.com/luikyv/go-oidc/internal/timeutil"
+	"github.com/luikyv/go-oidc/pkg/goidc"
+)
+
+func TestUserInfoEndpointDPoPNonce(t *testing.T) {
+	tests := []struct {
+		name       string
+		nonce      string
+		rotateTo   string
+		wantStatus int
+		wantNonce  string
+		wantError  goidc.ErrorCode
+	}{
+		{
+			name:       "challenge",
+			wantStatus: http.StatusUnauthorized,
+			wantNonce:  "challenge_nonce",
+			wantError:  goidc.ErrorCodeUseDPoPNonce,
+		},
+		{
+			name:       "success with reusable nonce",
+			nonce:      "current_nonce",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "success rotates nonce when requested",
+			nonce:      "current_nonce",
+			rotateTo:   "next_nonce",
+			wantStatus: http.StatusOK,
+			wantNonce:  "next_nonce",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := oidctest.NewContext(t)
+			ctx.DPoPEnabled = true
+			ctx.DPoPSigAlgs = []goidc.SignatureAlgorithm{goidc.SigAlgES256}
+			manager := oidctest.NewDPoPNonceManager(test.wantNonce)
+			ctx.DPoPNonceManager = manager
+			if test.nonce != "" {
+				manager.Add(goidc.DPoPNonceScopeResourceServer, test.nonce)
+			}
+			if test.rotateTo != "" {
+				manager.RotateWith(test.rotateTo)
+			}
+
+			client, _ := oidctest.NewClient(t)
+			ctx.StaticClients = append(ctx.StaticClients, client)
+			grant := &goidc.Grant{
+				ID:        "grant_id",
+				ClientID:  client.ID,
+				Subject:   "subject",
+				CreatedAt: timeutil.TimestampNow(),
+			}
+			if err := ctx.SaveGrant(grant); err != nil {
+				t.Fatalf("SaveGrant() error = %v", err)
+			}
+			ctx.UserInfoClaimsFunc = func(context.Context, *goidc.Grant) map[string]any { return nil }
+
+			key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			if err != nil {
+				t.Fatalf("GenerateKey() error = %v", err)
+			}
+			_, thumbprint := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method: http.MethodGet,
+				URI:    ctx.Host + ctx.UserInfoEndpoint,
+				Key:    key,
+			})
+			now := timeutil.TimestampNow()
+			accessToken := oidctest.Sign(t, map[string]any{
+				"jti":       "token_id",
+				"grant_id":  grant.ID,
+				"iss":       ctx.Issuer(),
+				"sub":       grant.Subject,
+				"client_id": client.ID,
+				"scope":     goidc.ScopeOpenID.ID,
+				"iat":       now,
+				"exp":       now + 60,
+				"cnf":       map[string]any{"jkt": thumbprint},
+			}, oidctest.PrivateJWKS(t, ctx).Keys[0])
+			proof, _ := oidctest.DPoPProof(t, oidctest.DPoPProofOptions{
+				Method:      http.MethodGet,
+				URI:         ctx.Host + ctx.UserInfoEndpoint,
+				AccessToken: accessToken,
+				Nonce:       test.nonce,
+				Key:         key,
+			})
+
+			req := httptest.NewRequest(http.MethodGet, ctx.UserInfoEndpoint, nil)
+			req.Header.Set("Authorization", fmt.Sprintf("DPoP %s", accessToken))
+			req.Header.Set(goidc.HeaderDPoP, proof)
+			rec := httptest.NewRecorder()
+			handle(oidc.NewHTTPContext(rec, req, ctx.Configuration))
+
+			if rec.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, test.wantStatus, rec.Body.String())
+			}
+			gotNonces := rec.Header().Values(goidc.HeaderDPoPNonce)
+			if test.wantNonce == "" && len(gotNonces) != 0 {
+				t.Fatalf("%s = %v, want empty", goidc.HeaderDPoPNonce, gotNonces)
+			}
+			if test.wantNonce != "" && (len(gotNonces) != 1 || gotNonces[0] != test.wantNonce) {
+				t.Fatalf("%s = %v, want [%s]", goidc.HeaderDPoPNonce, gotNonces, test.wantNonce)
+			}
+			if test.wantError != "" {
+				if !strings.Contains(rec.Body.String(), `"error":"`+string(test.wantError)+`"`) {
+					t.Fatalf("body = %s, want error %q", rec.Body.String(), test.wantError)
+				}
+				if got := rec.Header().Get("WWW-Authenticate"); !strings.Contains(got, `DPoP error="use_dpop_nonce"`) {
+					t.Fatalf("WWW-Authenticate = %q, want DPoP nonce challenge", got)
+				}
+			} else if got := rec.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("WWW-Authenticate = %q, want empty", got)
+			}
+		})
+	}
+}

--- a/pkg/goidc/dpop.go
+++ b/pkg/goidc/dpop.go
@@ -1,0 +1,46 @@
+package goidc
+
+import "context"
+
+// DPoPNonceScope identifies the server role that issued a DPoP nonce. Nonces
+// issued by an authorization server and a resource server are independent and
+// must not be accepted across scopes.
+type DPoPNonceScope string
+
+const (
+	DPoPNonceScopeAuthorizationServer DPoPNonceScope = "authorization_server"
+	DPoPNonceScopeResourceServer      DPoPNonceScope = "resource_server"
+)
+
+// DPoPNonceValidation is the result of validating a server-provided DPoP nonce.
+type DPoPNonceValidation struct {
+	// NextNonce optionally rotates the nonce on the current successful response.
+	// It must already be persisted as valid before ValidateNonce returns.
+	NextNonce string
+}
+
+// DPoPNonceManager issues and validates server-provided DPoP nonces.
+// Its methods may be called concurrently and implementations must be safe for
+// concurrent use.
+//
+// IssueNonce must generate an unpredictable nonce, persist it as valid for the
+// supplied scope before returning, and leave other outstanding nonces valid so
+// concurrent client requests remain usable. The returned value must use the
+// nonce syntax from RFC 9449 Section 8.1. Implementations are responsible for
+// expiring unused nonces.
+//
+// ValidateNonce must return ErrNotFound for an unknown or expired nonce. RFC
+// 9449 permits the same recent nonce to be accepted in multiple proofs. An
+// implementation may instead enforce single-use nonces, but then validation
+// and consumption must be one atomic operation so at most one concurrent call
+// succeeds. Any error other than ErrNotFound is treated as an operational
+// failure and fails closed.
+//
+// ValidateNonce may return a NextNonce to rotate the nonce in the successful
+// response. The replacement must be unpredictable, use the RFC 9449 nonce
+// syntax, and be persisted as valid before the method returns. Implementations
+// should retain a suitable window of recent nonces for concurrent requests.
+type DPoPNonceManager interface {
+	IssueNonce(context.Context, DPoPNonceScope) (string, error)
+	ValidateNonce(context.Context, DPoPNonceScope, string) (DPoPNonceValidation, error)
+}

--- a/pkg/goidc/error.go
+++ b/pkg/goidc/error.go
@@ -28,6 +28,7 @@ const (
 	ErrorCodeUnsupportedGrantType     ErrorCode = "unsupported_grant_type"
 	ErrorCodeInvalidRequestObject     ErrorCode = "invalid_request_object"
 	ErrorCodeInvalidToken             ErrorCode = "invalid_token"
+	ErrorCodeUseDPoPNonce             ErrorCode = "use_dpop_nonce"
 	ErrorCodeInternalError            ErrorCode = "internal_error"
 	ErrorCodeInvalidTarget            ErrorCode = "invalid_target"
 	ErrorCodeInvalidRedirectURI       ErrorCode = "invalid_redirect_uri"

--- a/pkg/goidc/model.go
+++ b/pkg/goidc/model.go
@@ -371,7 +371,8 @@ const (
 )
 
 const (
-	HeaderDPoP string = "DPoP"
+	HeaderDPoP      string = "DPoP"
+	HeaderDPoPNonce string = "DPoP-Nonce"
 )
 
 type Status string

--- a/pkg/goidc/model_test.go
+++ b/pkg/goidc/model_test.go
@@ -517,6 +517,7 @@ func TestErrorCodeStatusCode(t *testing.T) {
 		{goidc.ErrorCodeInvalidToken, http.StatusUnauthorized},
 		{goidc.ErrorCodeUnauthorizedClient, http.StatusUnauthorized},
 		{goidc.ErrorCodeInternalError, http.StatusInternalServerError},
+		{goidc.ErrorCodeUseDPoPNonce, http.StatusBadRequest},
 		{goidc.ErrorCodeInvalidRequest, http.StatusBadRequest},
 		{goidc.ErrorCodeInvalidGrant, http.StatusBadRequest},
 		{goidc.ErrorCodeInvalidScope, http.StatusBadRequest},

--- a/pkg/provider/option.go
+++ b/pkg/provider/option.go
@@ -1569,6 +1569,19 @@ func WithDPoPRequired() DPoPOption {
 	}
 }
 
+// WithDPoPNonce enables server-provided DPoP nonces.
+// The manager must use shared state when the provider has multiple
+// instances. See [goidc.DPoPNonceManager] for its atomicity requirements.
+func WithDPoPNonce(manager goidc.DPoPNonceManager) DPoPOption {
+	return func(p *Provider) error {
+		if manager == nil {
+			return errors.New("a DPoP nonce manager is required")
+		}
+		p.config.DPoPNonceManager = manager
+		return nil
+	}
+}
+
 // WithTokenBindingRequired makes at least one sender constraining mechanism
 // (TLS or DPoP) be required in order to issue an access token to a client.
 // For more info, see [WithMTLSTokenBinding] and [WithDPoP].

--- a/pkg/provider/option_test.go
+++ b/pkg/provider/option_test.go
@@ -1533,6 +1533,36 @@ func TestWithDPoPRequired(t *testing.T) {
 	}
 }
 
+func TestWithDPoPNonce(t *testing.T) {
+	manager := &dpopNonceManagerStub{}
+	p := &Provider{config: oidc.Configuration{}}
+
+	err := WithDPoP(
+		[]goidc.SignatureAlgorithm{goidc.SigAlgPS256},
+		WithDPoPNonce(manager),
+	)(p)
+
+	if err != nil {
+		t.Fatalf("WithDPoP() error = %v", err)
+	}
+	if p.config.DPoPNonceManager != manager {
+		t.Fatal("DPoPNonceManager was not configured")
+	}
+}
+
+func TestWithDPoPNonceRejectsNilManager(t *testing.T) {
+	p := &Provider{config: oidc.Configuration{}}
+
+	err := WithDPoP(
+		[]goidc.SignatureAlgorithm{goidc.SigAlgPS256},
+		WithDPoPNonce(nil),
+	)(p)
+
+	if err == nil {
+		t.Fatal("WithDPoP() error = nil, want an error")
+	}
+}
+
 func TestWithTokenBindingRequired(t *testing.T) {
 	// Given.
 	p := &Provider{
@@ -3268,4 +3298,14 @@ func TestWithScopes_OpenIDScopeAlreadyPresent(t *testing.T) {
 	if openIDCount != 1 {
 		t.Errorf("expected 1 openid scope, got %d", openIDCount)
 	}
+}
+
+type dpopNonceManagerStub struct{}
+
+func (*dpopNonceManagerStub) IssueNonce(context.Context, goidc.DPoPNonceScope) (string, error) {
+	return "nonce", nil
+}
+
+func (*dpopNonceManagerStub) ValidateNonce(context.Context, goidc.DPoPNonceScope, string) (goidc.DPoPNonceValidation, error) {
+	return goidc.DPoPNonceValidation{}, nil
 }


### PR DESCRIPTION
## Summary

- add an optional DPoP nonce manager with separate authorization-server and resource-server scopes
- issue RFC 9449 use_dpop_nonce challenges with exact status, header, nonce syntax, and cache behavior
- support reusable recent nonces, atomic single-use policies, and persisted positive-response rotation
- validate nonces across authorization-server DPoP paths and the UserInfo protected resource
- keep nonce-store failures fail closed and move legacy JTI consumption to the final proof-acceptance gate, converging with #132
- avoid validating the same proof twice in the self-issued pre-authorized-code flow

## Security behavior

Unknown, expired, missing, or syntactically invalid nonces receive a fresh challenge. Operational manager failures remain internal errors and never downgrade to nonce challenges. Implementations must be safe for concurrent use and share state across replicas. Exactly one DPoP-Nonce field is emitted and nonce-bearing responses are marked no-store.

## Verification

- go test ./...
- go test -race ./internal/dpop ./internal/token ./internal/userinfo ./pkg/provider ./pkg/goidc
- go vet ./...
- golangci-lint run
- git diff --check

References: RFC 9449 Sections 7 through 9.